### PR TITLE
deps: build mutator with external sources

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -31,10 +31,10 @@ serde_json = "1.0"
 tempfile = "3.10"
 toml = "0.5"
 
-move-command-line-common = { path = "../../move-command-line-common" }
-move-compiler = { path = "../../move-compiler" }
-move-compiler-v2 = { path = "../../move-compiler-v2" }
-move-ir-types = { path = "../../move-ir/types" }
-move-model = { path = "../../move-model" }
-move-package = { path = "../move-package" }
-move-symbol-pool = { path = "../../move-symbol-pool" }
+move-command-line-common = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-compiler = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-compiler-v2 = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-ir-types = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-model = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-package = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-symbol-pool = { git = "https://github.com/Rqnsom/aptos-core.git" }

--- a/third_party/move/tools/move-spec-test/Cargo.toml
+++ b/third_party/move/tools/move-spec-test/Cargo.toml
@@ -26,8 +26,8 @@ tabled = "0.15"
 tempfile = "3.10"
 termcolor = "1.1"
 
-move-command-line-common = { path = "../../move-command-line-common" }
-move-model = { path = "../../move-model" }
+move-command-line-common = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-model = { git = "https://github.com/Rqnsom/aptos-core.git" }
 move-mutator = { path = "../move-mutator" }
-move-package = { path = "../move-package" }
-move-prover = { path = "../../move-prover" }
+move-package = { git = "https://github.com/Rqnsom/aptos-core.git" }
+move-prover = { git = "https://github.com/Rqnsom/aptos-core.git" }


### PR DESCRIPTION
For now we will use a modified fork here:
https://github.com/Rqnsom/aptos-core

Until this [PR](https://github.com/aptos-labs/aptos-core/pull/14385) gets merged into the official aptos-core repo.