### PR TITLE
 ci: basic lint and fmt check 

### DIFF
--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -1,0 +1,32 @@
+name: Basic check and lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  basic-lint-and-check:
+    runs-on: ubuntu-latest
+    name: Basic ci-check for fmt/clippy/check
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: nightly
+
+      - name: Run check
+        run: cargo +nightly check --all-targets
+
+      - name: Run fmt
+        run: cargo +nightly fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo +nightly clippy --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fixed-hash"
@@ -730,7 +730,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1953,7 +1953,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2252,7 +2252,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2338,9 +2338,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -2366,20 +2366,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -2565,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2665,7 +2665,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2694,7 +2694,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2904,7 +2904,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -2926,7 +2926,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3194,5 +3194,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]

--- a/move-mutator/src/configuration.rs
+++ b/move-mutator/src/configuration.rs
@@ -180,18 +180,17 @@ mod tests {
         fs::write("test.toml", toml_content).unwrap();
         let config = Configuration::from_toml_file(Path::new("test.toml")).unwrap();
         fs::remove_file("test.toml").unwrap();
-        assert_eq!(
-            config.project.move_sources,
-            vec![Path::new("/path/to/move/source")]
-        );
+        assert_eq!(config.project.move_sources, vec![Path::new(
+            "/path/to/move/source"
+        )]);
         assert_eq!(
             config.project.mutate_modules,
             ModuleFilter::Selected(vec!["module1".to_owned(), "module2".to_owned()])
         );
-        assert_eq!(
-            config.mutation.unwrap().operators,
-            vec!["operator1", "operator2"]
-        );
+        assert_eq!(config.mutation.unwrap().operators, vec![
+            "operator1",
+            "operator2"
+        ]);
         assert_eq!(config.individual.len(), 1);
         assert_eq!(config.individual[0].file, PathBuf::from("/path/to/file"));
         assert!(config.individual[0].verify_mutants);
@@ -253,10 +252,9 @@ mod tests {
         fs::write("test.json", json_content).unwrap();
         let config = Configuration::from_json_file(Path::new("test.json")).unwrap();
         fs::remove_file("test.json").unwrap();
-        assert_eq!(
-            config.project.move_sources,
-            vec![Path::new("/path/to/move/source")]
-        );
+        assert_eq!(config.project.move_sources, vec![Path::new(
+            "/path/to/move/source"
+        )]);
         assert_eq!(config.project.mutate_modules, ModuleFilter::All);
         assert_eq!(
             config.project.out_mutant_dir,
@@ -270,10 +268,10 @@ mod tests {
             Path::new("/path/to/configuration")
         );
         assert_eq!(config.project_path.unwrap(), Path::new("/path/to/project"));
-        assert_eq!(
-            config.mutation.unwrap().operators,
-            vec!["operator1", "operator2"]
-        );
+        assert_eq!(config.mutation.unwrap().operators, vec![
+            "operator1",
+            "operator2"
+        ]);
     }
 
     #[test]

--- a/move-mutator/src/main.rs
+++ b/move-mutator/src/main.rs
@@ -5,8 +5,7 @@
 #![forbid(unsafe_code)]
 
 use clap::Parser;
-use move_mutator::cli::CLIOptions;
-use move_mutator::run_move_mutator;
+use move_mutator::{cli::CLIOptions, run_move_mutator};
 use move_package::BuildConfig;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/move-mutator/src/operators/literal.rs
+++ b/move-mutator/src/operators/literal.rs
@@ -197,7 +197,7 @@ mod tests {
             loc,
         );
         let source = "51";
-        let expected = vec![
+        let expected = [
             u8::MIN.to_string(),
             u8::MAX.to_string(),
             "52".to_owned(),
@@ -222,7 +222,7 @@ mod tests {
             loc,
         );
         let source = "963";
-        let expected = vec![
+        let expected = [
             u16::MIN.to_string(),
             u16::MAX.to_string(),
             "964".to_owned(),
@@ -247,7 +247,7 @@ mod tests {
             loc,
         );
         let source = "1000963";
-        let expected = vec![
+        let expected = [
             u32::MIN.to_string(),
             u32::MAX.to_string(),
             "1000964".to_owned(),
@@ -272,7 +272,7 @@ mod tests {
             loc,
         );
         let source = "963251000963";
-        let expected = vec![
+        let expected = [
             u64::MIN.to_string(),
             u64::MAX.to_string(),
             "963251000964".to_owned(),
@@ -297,7 +297,7 @@ mod tests {
             loc,
         );
         let source = "123963251000963";
-        let expected = vec![
+        let expected = [
             u128::MIN.to_string(),
             u128::MAX.to_string(),
             "123963251000964".to_owned(),

--- a/move-mutator/src/operators/mod.rs
+++ b/move-mutator/src/operators/mod.rs
@@ -29,6 +29,7 @@ pub(crate) const MOVE_ADDR_MAX: &str =
     "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ExpLoc {
     pub exp: Exp,
     pub loc: Loc,

--- a/move-mutator/src/report.rs
+++ b/move-mutator/src/report.rs
@@ -136,6 +136,7 @@ impl Range {
 }
 
 /// The `Mutation` struct represents a modification that was applied to a file.
+///
 /// It contains the location of the modification, the name of the mutation operator, the old value and the new value.
 /// It is used to represent a single modification inside a `ReportEntry`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/move-spec-test/src/cli.rs
+++ b/move-spec-test/src/cli.rs
@@ -2,6 +2,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::too_long_first_doc_paragraph)]
+
 use clap::Parser;
 use move_mutator::cli::ModuleFilter;
 use serde::{Deserialize, Serialize};

--- a/move-spec-test/src/lib.rs
+++ b/move-spec-test/src/lib.rs
@@ -2,6 +2,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::too_long_first_doc_paragraph)]
+
 mod benchmark;
 pub mod cli;
 mod prover;
@@ -22,8 +24,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// This function runs the specification testing, which is a combination of the
-/// mutator tool and the prover tool
+/// This function runs the specification testing, which is a combination of the mutator tool and the prover tool.
+///
 /// It takes the CLI options and constructs appropriate options for the
 /// Move Mutator tool and Move Prover tool. Then it mutates the code storing
 /// results in a temporary directory. Then it runs the prover on the mutated

--- a/move-spec-test/src/main.rs
+++ b/move-spec-test/src/main.rs
@@ -6,8 +6,7 @@
 
 use clap::Parser;
 use move_package::BuildConfig;
-use move_spec_test::cli::CLIOptions;
-use move_spec_test::run_spec_test;
+use move_spec_test::{cli::CLIOptions, run_spec_test};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 

--- a/move-spec-test/src/prover.rs
+++ b/move-spec-test/src/prover.rs
@@ -25,9 +25,9 @@ pub(crate) fn prove<W: WriteColor>(
     prover_conf: &move_prover::cli::Options,
     mut error_writer: &mut W,
 ) -> anyhow::Result<()> {
-    let mut model = config.clone().move_model_for_package(
-        package_path,
-        ModelConfig {
+    let mut model = config
+        .clone()
+        .move_model_for_package(package_path, ModelConfig {
             all_files_as_targets: true,
             target_filter: None,
             compiler_version: config
@@ -38,8 +38,7 @@ pub(crate) fn prove<W: WriteColor>(
                 .compiler_config
                 .language_version
                 .unwrap_or(LanguageVersion::V1),
-        },
-    )?;
+        })?;
 
     let mut prover_conf = prover_conf.clone();
     prover_conf.output_path = package_path


### PR DESCRIPTION
The new worfklow runs:
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`

The PR includes two commits:
- fmt check
- resolved clippy warnings