### PR TITLE
chore(move-mutator): improve single file err handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,7 @@ dependencies = [
  "anyhow",
  "clap",
  "codespan",
+ "codespan-reporting",
  "diffy",
  "either",
  "itertools 0.12.1",
@@ -1515,6 +1516,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "termcolor",
  "toml 0.5.11",
 ]
 

--- a/move-mutator/Cargo.toml
+++ b/move-mutator/Cargo.toml
@@ -19,18 +19,11 @@ path = "src/main.rs"
 anyhow = "1.0"
 clap = { version = "4.3", features = ["derive"] }
 codespan = "0.11"
+codespan-reporting = "0.11"
 diffy = "0.3"
 either = "1.9"
 itertools = "0.12"
 log = "0.4"
-num-traits = "0.2"
-pretty_env_logger = "0.5"
-rand = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
-tempfile = "3.10"
-toml = "0.5"
-
 move-command-line-common = { git = "https://github.com/aptos-labs/aptos-core.git" }
 move-compiler = { git = "https://github.com/aptos-labs/aptos-core.git" }
 move-compiler-v2 = { git = "https://github.com/aptos-labs/aptos-core.git" }
@@ -38,3 +31,11 @@ move-ir-types = { git = "https://github.com/aptos-labs/aptos-core.git" }
 move-model = { git = "https://github.com/aptos-labs/aptos-core.git" }
 move-package = { git = "https://github.com/aptos-labs/aptos-core.git" }
 move-symbol-pool = { git = "https://github.com/aptos-labs/aptos-core.git" }
+num-traits = "0.2"
+pretty_env_logger = "0.5"
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+tempfile = "3.10"
+termcolor = "1.1"
+toml = "0.5"

--- a/move-mutator/src/compiler.rs
+++ b/move-mutator/src/compiler.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::configuration::Configuration;
+use codespan_reporting::diagnostic::Severity;
 use either::Either;
 use itertools::Itertools;
 use move_command_line_common::{address::NumericalAddress, parser::NumberFormat};
@@ -72,6 +73,12 @@ pub fn generate_ast(
     };
 
     let env = run_checker(options.clone())?;
+
+    if env.has_errors() {
+        let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
+        env.report_diag(&mut error_writer, Severity::Warning);
+        anyhow::bail!("AST generation failed");
+    }
 
     trace!("Sources parsed successfully, AST generated");
 

--- a/move-mutator/src/lib.rs
+++ b/move-mutator/src/lib.rs
@@ -77,7 +77,7 @@ pub fn run_move_mutator(
             .as_path(),
     )?;
 
-    trace!("Generated AST.");
+    trace!("Generated AST");
 
     let mutants = mutate::mutate(&env, &mutator_configuration)?;
     let output_dir = output::setup_output_dir(&mutator_configuration)?;

--- a/move-mutator/tests/basic_tests.rs
+++ b/move-mutator/tests/basic_tests.rs
@@ -124,9 +124,9 @@ fn check_mutator_fails_on_non_existing_output_path() {
     assert!(result.is_err());
 }
 
-// Check if the mutator works with single files.
+// Check if the mutator works with single files that do not require deps/address resolving.
 #[test]
-fn check_mutator_works_with_single_files() {
+fn check_mutator_works_with_simple_single_files() {
     let outdir = tempdir().unwrap().into_path();
 
     let options = CLIOptions {
@@ -152,6 +152,33 @@ fn check_mutator_works_with_single_files() {
 
     let report = move_mutator::report::Report::load_from_json_file(&report_path).unwrap();
     assert!(!report.get_mutants().is_empty());
+}
+
+// Check if the mutator fails properly with single files that do require deps/address resolving.
+#[test]
+fn check_mutator_properly_fails_with_single_files_that_require_dep_or_addr_resolving() {
+    let outdir = tempdir().unwrap().into_path();
+
+    let options = CLIOptions {
+        move_sources: vec!["tests/move-assets/simple/sources/Sum.move".into()],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some(outdir.clone()),
+        verify_mutants: false,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    let package_path = Path::new(".");
+
+    let result = move_mutator::run_move_mutator(options.clone(), &config, package_path);
+    assert!(result.is_err());
+
+    let report_path = outdir.join("report.json");
+    assert!(!report_path.exists());
 }
 
 // Check if the mutator produce zero mutants if verification is enabled for


### PR DESCRIPTION
Single files can be mutated only if the files require no deps or address name resolving - in those cases we should printout a proper error in the output.

An example:
```sh
$ ./target/release/move-mutator -m move-mutator/tests/move-assets/simple/sources/Sum.move
error: address with no value
  ┌─ move-mutator/tests/move-assets/simple/sources/Sum.move:1:8
  │
1 │ module TestAccount::Sum {
  │        ^^^^^^^^^^^ address 'TestAccount' is not assigned a value. Try assigning it a value when calling the compiler

Error: AST generation failed
```