### PR TITLE
test: add move tests for projects in move-assets

### DIFF
--- a/move-mutator/tests/move-assets/breakcontinue/Move.toml
+++ b/move-mutator/tests/move-assets/breakcontinue/Move.toml
@@ -2,5 +2,9 @@
 name = "breakcontinue"
 version = "0.0.0"
 
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
 [addresses]
+std =  "0x1"
 TestAccount = "0xCAFE"

--- a/move-mutator/tests/move-assets/breakcontinue/sources/Break.move
+++ b/move-mutator/tests/move-assets/breakcontinue/sources/Break.move
@@ -9,4 +9,19 @@ module TestAccount::Break {
 
         i
     }
+
+    // We won't be able to kill two mutants:
+    //  - while (i < n)
+    //  - if (n % i <= 0) break;
+    #[test]
+    fun smallest_factor_test() {
+        // These two should fail - but let's keep imperfect code here
+        assert!(smallest_factor(0) == 2, 0);
+        assert!(smallest_factor(1) == 2, 0);
+
+        assert!(smallest_factor(2) == 2, 0);
+        assert!(smallest_factor(9) == 3, 0);
+        assert!(smallest_factor(35) == 5, 0);
+        assert!(smallest_factor(91) == 7, 0);
+    }
 }

--- a/move-mutator/tests/move-assets/breakcontinue/sources/BreakContinue.move
+++ b/move-mutator/tests/move-assets/breakcontinue/sources/BreakContinue.move
@@ -11,4 +11,22 @@ module TestAccount::BreakContinue {
 
         sum
     }
+
+    // We won't be able to kill one mutant:
+    //  - if (n % i <= 0) break;
+    #[test]
+    fun sum_intermediate_test() {
+        assert!(sum_intermediate(0) == 0, 0);
+        assert!(sum_intermediate(1) == 1, 0);
+        assert!(sum_intermediate(2) == 3, 0);
+        assert!(sum_intermediate(3) == 6, 0);
+        assert!(sum_intermediate(4) == 10, 0);
+        assert!(sum_intermediate(5) == 15, 0);
+        assert!(sum_intermediate(6) == 21, 0);
+        assert!(sum_intermediate(7) == 28, 0);
+        assert!(sum_intermediate(8) == 36, 0);
+        assert!(sum_intermediate(9) == 45, 0);
+        assert!(sum_intermediate(10) == 45, 0);
+        assert!(sum_intermediate(11) == 56, 0);
+    }
 }

--- a/move-mutator/tests/move-assets/breakcontinue/sources/Continue.move
+++ b/move-mutator/tests/move-assets/breakcontinue/sources/Continue.move
@@ -10,4 +10,23 @@ module TestAccount::Continue {
 
         sum
     }
+
+    // We won't be able to kill two mutants:
+    //  - while (i != n) {
+    //  - if (i % 10 <= 0)
+    #[test]
+    fun sum_intermediate_test() {
+        assert!(sum_intermediate(0) == 0, 0);
+        assert!(sum_intermediate(1) == 1, 0);
+        assert!(sum_intermediate(2) == 3, 0);
+        assert!(sum_intermediate(3) == 6, 0);
+        assert!(sum_intermediate(4) == 10, 0);
+        assert!(sum_intermediate(5) == 15, 0);
+        assert!(sum_intermediate(6) == 21, 0);
+        assert!(sum_intermediate(7) == 28, 0);
+        assert!(sum_intermediate(8) == 36, 0);
+        assert!(sum_intermediate(9) == 45, 0);
+        assert!(sum_intermediate(10) == 45, 0);
+        assert!(sum_intermediate(11) == 56, 0);
+    }
 }

--- a/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
+++ b/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
@@ -2,5 +2,9 @@
 name = "p1"
 version = "0.0.0"
 
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
 [addresses]
+std =  "0x1"
 TestAccount = "0xCAFE2"

--- a/move-mutator/tests/move-assets/relative_dep/p1/sources/Mul.move
+++ b/move-mutator/tests/move-assets/relative_dep/p1/sources/Mul.move
@@ -7,4 +7,24 @@ module TestAccount::Mul {
 
         mult
     }
+
+    #[test]
+    fun mul_test() {
+        assert!(mul(0, 0) == 0, 0);
+        assert!(mul(1, 0) == 0, 0);
+        assert!(mul(0, 2) == 0, 0);
+        assert!(mul(1, 3) == 3, 0);
+        assert!(mul(4, 1) == 4, 0);
+        assert!(mul(4, 1) == 4, 0);
+        assert!(mul(5, 2) == 10, 0);
+        assert!(mul(2, 6) == 12, 0);
+        assert!(mul(7, 7) == 49, 0);
+    }
+
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Mul)]
+    fun mul_overflow_failure_test() {
+        let a = 1 << 64;
+        let b = 1 << 64;
+        assert!(mul(a, b) != 0, 0);
+    }
 }

--- a/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
+++ b/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
@@ -4,7 +4,9 @@ version = "0.0.0"
 
 [dependencies]
 p1 = { local = "../p1" }
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
 
 [addresses]
+std =  "0x1"
 CafeAccount = "0xCAFE"
 TestAccount = "0xCAFE2"

--- a/move-mutator/tests/move-assets/relative_dep/p2/sources/MulUse.move
+++ b/move-mutator/tests/move-assets/relative_dep/p2/sources/MulUse.move
@@ -6,4 +6,18 @@ module CafeAccount::MulUse {
         let w = y + 2;
         mul(z, w)
     }
+
+    #[test]
+    fun mul_usage_test() {
+        assert!(mul_usage(0, 0) == 2, 0);
+        assert!(mul_usage(1, 0) == 4, 0);
+        assert!(mul_usage(6, 5) == 49, 0);
+    }
+
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Mul)]
+    fun mul_usage_overflow_failure_test() {
+        let a = 1 << 64;
+        let b = 1 << 64;
+        assert!(mul_usage(a, b) != 0, 0);
+    }
 }

--- a/move-mutator/tests/move-assets/simple/Move.toml
+++ b/move-mutator/tests/move-assets/simple/Move.toml
@@ -2,5 +2,9 @@
 name = "simple"
 version = "0.0.0"
 
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
 [addresses]
+std =  "0x1"
 TestAccount = "0xCAFE"

--- a/move-mutator/tests/move-assets/simple/sources/Negation.move
+++ b/move-mutator/tests/move-assets/simple/sources/Negation.move
@@ -3,6 +3,12 @@ module TestAccount::Negation {
         !x
     }
 
+    #[test]
+    fun neg_log_test() {
+        assert!(neg_log(true) == false, 0);
+        assert!(neg_log(false) == true, 0);
+    }
+
     spec neg_log {
         ensures result == !x;
     }

--- a/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -46,6 +46,13 @@ module TestAccount::Operators {
         assert!(mul(7, 7) == 49, 0);
     }
 
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Operators)]
+    fun mul_overflow_failure_test() {
+        let a = 1 << 64;
+        let b = 1 << 64;
+        assert!(mul(a, b) != 0, 0);
+    }
+
     fun mod(x: u64, y: u64): u64 {
         x % y
     }
@@ -162,7 +169,6 @@ module TestAccount::Operators {
         x << y
     }
 
-    // TODO: the prototype tool requires --verify-mutants flag here, investigate this a bit
     #[test]
     fun lsh_valid_usage_test() {
         assert!(lsh(0, 0) == 0, 0);
@@ -233,7 +239,6 @@ module TestAccount::Operators {
         !x
     }
 
-    //// TODO: the prototype tool requires --verify-mutants flag here, investigate this a bit
     #[test]
     fun logical_not_valid_usage_test() {
         assert!(logical_not(true) == false, 0);

--- a/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -3,76 +3,337 @@ module TestAccount::Operators {
         x + y
     }
 
+    #[test]
+    fun sum_valid_usage_test() {
+        assert!(sum(0, 0) == 0, 0);
+        assert!(sum(1, 0) == 1, 0);
+        assert!(sum(0, 1) == 1, 0);
+        assert!(sum(5, 5) == 10, 0);
+        assert!(sum(50, 10) == 60, 0);
+    }
+
     fun sub(x: u64, y: u64): u64 {
         x - y
+    }
+
+    #[test]
+    fun sub_valid_usage_test() {
+        assert!(sub(0, 0) == 0, 0);
+        assert!(sub(1, 0) == 1, 0);
+        assert!(sub(5, 5) == 0, 0);
+        assert!(sub(50, 10) == 40, 0);
+    }
+
+    #[test, expected_failure]
+    fun sub_invalid_usage_test() {
+        assert!(sub(0, 5) == 0, 0);
     }
 
     fun mul(x: u64, y: u64): u64 {
         x * y
     }
 
+    #[test]
+    fun mul_valid_usage_test() {
+        assert!(mul(0, 0) == 0, 0);
+        assert!(mul(1, 0) == 0, 0);
+        assert!(mul(0, 2) == 0, 0);
+        assert!(mul(1, 3) == 3, 0);
+        assert!(mul(4, 1) == 4, 0);
+        assert!(mul(4, 1) == 4, 0);
+        assert!(mul(5, 2) == 10, 0);
+        assert!(mul(2, 6) == 12, 0);
+        assert!(mul(7, 7) == 49, 0);
+    }
+
     fun mod(x: u64, y: u64): u64 {
         x % y
+    }
+
+    #[test]
+    fun mod_valid_usage_test() {
+        assert!(mod(0, 1) == 0, 0);
+        assert!(mod(0, 2) == 0, 0);
+        assert!(mod(2, 2) == 0, 0);
+        assert!(mod(4, 4) == 0, 0);
+
+        assert!(mod(0, 3) == 0, 0);
+        assert!(mod(1, 3) == 1, 0);
+        assert!(mod(2, 3) == 2, 0);
+        assert!(mod(3, 3) == 0, 0);
+        assert!(mod(4, 3) == 1, 0);
+        assert!(mod(5, 3) == 2, 0);
+        assert!(mod(6, 3) == 0, 0);
+
+        assert!(mod(67, 65) == 2, 0);
+        assert!(mod(40, 45) == 40, 0);
+    }
+
+    // TODO: This test is important as it covers division by zero. At the moment - move-mutation test cannot detect if this test is missing
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Operators)]
+    fun mod_invalid_usage_test() {
+        assert!(mod(5, 0) != 1000, 0);
     }
 
     fun div(x: u64, y: u64): u64 {
         x / y
     }
 
+    #[test]
+    fun div_valid_usage_test() {
+        assert!(div(0, 1) == 0, 0);
+        assert!(div(0, 2) == 0, 0);
+        assert!(div(1, 2) == 0, 0);
+        assert!(div(2, 2) == 1, 0);
+
+        assert!(div(200, 10) == 20, 0);
+        assert!(div(205, 10) == 20, 0);
+        assert!(div(210, 10) == 21, 0);
+
+        assert!(div(67, 65) == 1, 0);
+        assert!(div(40, 45) == 0, 0);
+    }
+
+    // TODO: This test is important as it covers division by zero. At the moment - move-mutation test cannot detect if this test is missing
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Operators)]
+    fun div_invalid_usage_test() {
+        assert!(div(50, 0) != 1000, 0);
+    }
+
     fun and(x: u64, y: u64): u64 {
         x & y
+    }
+
+    // Info: we won't kill a mutant that swaps places (false-positive)
+    #[test]
+    fun and_valid_usage_test() {
+        assert!(and(0, 0) == 0, 0);
+        assert!(and(1, 0) == 0, 0);
+        assert!(and(0, 2) == 0, 0);
+        assert!(and(1, 1) == 1, 0);
+        assert!(and(3, 3) == 3, 0);
+        assert!(and(3, 2) == 2, 0);
+        assert!(and(3, 4) == 0, 0);
+
+        assert!(and(8, 5) == 0, 0);
+        assert!(and(8, 9) == 8, 0);
+        assert!(and(8, 63) == 8, 0);
+        assert!(and(65, 64) == 64, 0);
     }
 
     fun or(x: u64, y: u64): u64 {
         x | y
     }
 
+    // Info: we won't kill a mutant that swaps places (false-positive)
+    #[test]
+    fun or_valid_usage_test() {
+        assert!(or(0, 0) == 0, 0);
+        assert!(or(1, 0) == 1, 0);
+        assert!(or(0, 2) == 2, 0);
+        assert!(or(1, 1) == 1, 0);
+        assert!(or(3, 3) == 3, 0);
+        assert!(or(3, 2) == 3, 0);
+        assert!(or(3, 4) == 7, 0);
+
+        assert!(or(8, 5) == 13, 0);
+        assert!(or(8, 9) == 9, 0);
+        assert!(or(8, 63) == 63, 0);
+        assert!(or(65, 64) == 65, 0);
+        assert!(or(128, 0) == 128, 0);
+    }
+
     fun xor(x: u64, y: u64): u64 {
         x ^ y
+    }
+
+    // Info: we won't kill a mutant that swaps places (false-positive)
+    #[test]
+    fun xor_valid_usage_test() {
+        assert!(xor(0, 0) == 0, 0);
+        assert!(xor(1, 1) == 0, 0);
+        assert!(xor(1, 0) == 1, 0);
+        assert!(xor(0, 2) == 2, 0);
+        assert!(xor(1, 2) == 3, 0);
+        assert!(xor(128, 0) == 128, 0);
     }
 
     fun lsh(x: u64, y: u8): u64 {
         x << y
     }
 
+    // TODO: the prototype tool requires --verify-mutants flag here, investigate this a bit
+    #[test]
+    fun lsh_valid_usage_test() {
+        assert!(lsh(0, 0) == 0, 0);
+        assert!(lsh(1, 0) == 1, 0);
+        assert!(lsh(2, 0) == 2, 0);
+        assert!(lsh(3, 0) == 3, 0);
+        assert!(lsh(16, 0) == 16, 0);
+        assert!(lsh(17, 0) == 17, 0);
+
+        assert!(lsh(0, 1) == 0, 0);
+        assert!(lsh(1, 1) == 2, 0);
+        assert!(lsh(2, 1) == 4, 0);
+        assert!(lsh(3, 1) == 6, 0);
+        assert!(lsh(16, 1) == 32, 0);
+        assert!(lsh(17, 1) == 34, 0);
+        assert!(lsh(18, 2) == 72, 0);
+    }
+
     fun rsh(x: u64, y: u8): u64 {
         x >> y
+    }
+
+    #[test]
+    fun rsh_valid_usage_test() {
+        assert!(rsh(0, 0) == 0, 0);
+        assert!(rsh(1, 0) == 1, 0);
+        assert!(rsh(2, 0) == 2, 0);
+        assert!(rsh(3, 0) == 3, 0);
+        assert!(rsh(16, 0) == 16, 0);
+        assert!(rsh(17, 0) == 17, 0);
+
+        assert!(rsh(0, 1) == 0, 0);
+        assert!(rsh(1, 1) == 0, 0);
+        assert!(rsh(2, 1) == 1, 0);
+        assert!(rsh(3, 1) == 1, 0);
+        assert!(rsh(16, 1) == 8, 0);
+        assert!(rsh(17, 1) == 8, 0);
+        assert!(rsh(18, 2) == 4, 0);
     }
 
     fun logical_or(x: bool, y: bool): bool {
         x || y
     }
 
+    // Info: we won't kill a mutant that swaps places (false-positive)
+    #[test]
+    fun logical_or_valid_usage_test() {
+        assert!(logical_or(true, true) == true, 0);
+        assert!(logical_or(false, false) == false, 0);
+        assert!(logical_or(true, false) == true, 0);
+        assert!(logical_or(false, true) == true, 0);
+    }
+
     fun logical_and(x: bool, y: bool): bool {
         x && y
+    }
+
+    // Info: we won't kill a mutant that swaps places (false-positive)
+    #[test]
+    fun logical_and_valid_usage_test() {
+        assert!(logical_and(true, true) == true, 0);
+        assert!(logical_and(false, false) == false, 0);
+        assert!(logical_and(true, false) == false, 0);
+        assert!(logical_and(false, true) == false, 0);
     }
 
     fun logical_not(x: bool): bool {
         !x
     }
 
+    //// TODO: the prototype tool requires --verify-mutants flag here, investigate this a bit
+    #[test]
+    fun logical_not_valid_usage_test() {
+        assert!(logical_not(true) == false, 0);
+        assert!(logical_not(false) == true, 0);
+    }
+
     fun eq(x: u8, y: u8): bool {
         x == y
+    }
+
+    #[test]
+    fun eq_valid_usage_test() {
+        assert!(eq(1, 1) == true, 0);
+        assert!(eq(0, 0) == true, 0);
+        assert!(eq(63, 63) == true, 0);
+
+        assert!(eq(1, 0) == false, 0);
+        assert!(eq(2, 1) == false, 0);
+        assert!(eq(6, 5) == false, 0);
+        assert!(eq(4, 7) == false, 0);
     }
 
     fun neq(x: u8, y: u8): bool {
         x != y
     }
 
+    #[test]
+    fun neq_valid_usage_test() {
+        assert!(neq(1, 1) == false, 0);
+        assert!(neq(0, 0) == false, 0);
+        assert!(neq(63, 63) == false, 0);
+
+        assert!(neq(1, 0) == true, 0);
+        assert!(neq(2, 1) == true, 0);
+        assert!(neq(6, 5) == true, 0);
+        assert!(neq(4, 7) == true, 0);
+    }
+
     fun lt(x: u64, y: u64): bool {
         x < y
+    }
+
+    #[test]
+    fun lt_valid_usage_test() {
+        assert!(lt(1, 1) == false, 0);
+        assert!(lt(0, 0) == false, 0);
+        assert!(lt(63, 63) == false, 0);
+
+        assert!(lt(1, 0) == false, 0);
+        assert!(lt(2, 1) == false, 0);
+        assert!(lt(6, 5) == false, 0);
+        assert!(lt(4, 7) == true, 0);
     }
 
     fun lte(x: u64, y: u64): bool {
         x <= y
     }
 
+    #[test]
+    fun lte_valid_usage_test() {
+        assert!(lte(1, 1) == true, 0);
+        assert!(lte(0, 0) == true, 0);
+        assert!(lte(63, 63) == true, 0);
+
+        assert!(lte(1, 0) == false, 0);
+        assert!(lte(2, 1) == false, 0);
+        assert!(lte(6, 5) == false, 0);
+        assert!(lte(4, 7) == true, 0);
+    }
+
     fun gt(x: u64, y: u64): bool {
         x > y
     }
 
+    #[test]
+    fun gt_valid_usage_test() {
+        assert!(gt(1, 1) == false, 0);
+        assert!(gt(0, 0) == false, 0);
+        assert!(gt(63, 63) == false, 0);
+
+        assert!(gt(1, 0) == true, 0);
+        assert!(gt(2, 1) == true, 0);
+        assert!(gt(6, 5) == true, 0);
+        assert!(gt(4, 7) == false, 0);
+    }
+
     fun gte(x: u64, y: u64): bool {
         x >= y
+    }
+
+    #[test]
+    fun gte_valid_usage_test() {
+        assert!(gte(1, 1) == true, 0);
+        assert!(gte(0, 0) == true, 0);
+        assert!(gte(63, 63) == true, 0);
+
+        assert!(gte(1, 0) == true, 0);
+        assert!(gte(2, 1) == true, 0);
+        assert!(gte(6, 5) == true, 0);
+        assert!(gte(4, 7) == false, 0);
     }
 
     spec sum {
@@ -150,5 +411,4 @@ module TestAccount::Operators {
     spec gte {
         ensures result == (x >= y);
     }
-
 }

--- a/move-mutator/tests/move-assets/simple/sources/StillSimple.move
+++ b/move-mutator/tests/move-assets/simple/sources/StillSimple.move
@@ -2,15 +2,37 @@ module TestAccount::StillSimple {
     fun sample1(x: u128, y: u128) {
         let _sum_r = x + y;
 
-	    if ((x + y) < 0) abort 1;
+        // Impossible condition here:
+        if ((x + y) < 0) abort 1;
+    }
+
+    // This test will generate mutants that will survive and indicate the impossible condition in the code.
+    #[test]
+    fun sample1_valid_usage_test() {
+        sample1(0, 0);
+        sample1(2, 1);
+        sample1(1, 2);
     }
 
     inline fun apply(v: u64, predicate: |u64| bool): bool {
         predicate(v)
     }
 
-    fun sample2(a1: u64, a2: u64) {
-        let _lamb = apply(0, |v| v != a1 + a2);
+    fun sample2(a1: u64, a2: u64): bool {
+        let lamb = apply(0, |v| v != a1 + a2);
+        lamb
+    }
+
+    #[test]
+    fun sample2_valid_usage_test() {
+        // The only case where it's gonna be false
+        assert!(sample2(0, 0) == false, 0);
+
+        assert!(sample2(0, 5) == true, 0);
+        assert!(sample2(5, 0) == true, 0);
+
+        assert!(sample2(1, 2) == true, 0);
+        assert!(sample2(2, 1) == true, 0);
     }
 
     public fun sample3(n: u64, e: u64): u64 {
@@ -23,6 +45,24 @@ module TestAccount::StillSimple {
 
     spec sample3 {
         pragma opaque;
+    }
+
+    #[test]
+    fun sample3_valid_usage_test() {
+        assert!(sample3(5, 0) == 1, 0);
+        assert!(sample3(5, 1) == 5, 0);
+        assert!(sample3(5, 2) == 25, 0);
+        assert!(sample3(5, 3) == 125, 0);
+
+        assert!(sample3(2, 8) == 256, 0);
+        assert!(sample3(2, 16) == 65536, 0);
+
+        assert!(sample3(1, 64) == 1, 0);
+        assert!(sample3(1, 512) == 1, 0);
+        assert!(sample3(0, 5) == 0, 0);
+
+        // Huge number, let's assume it's not 5 instead :D
+        assert!(sample3(521, 5) != 5, 0);
     }
 
     fun sample4(x: u128, y: u128) {
@@ -39,11 +79,70 @@ module TestAccount::StillSimple {
         };
     }
 
+    #[test]
+    fun sample4_valid_usage_test() {
+        // Does this test even make any sense?
+        sample4(0, 3);
+        sample4(3, 0);
+        sample4(5, 5);
+    }
+
     fun sample5(x: u128, y: u128): u128 {
         (x - 1 as u128) + (y - 1 as u128)
     }
 
+    #[test]
+    fun sample5_valid_usage_test() {
+        let expected_result = 4;
+        let result = sample5(3, 3);
+        assert!(expected_result == result, 1);
+
+        let expected_result = 0;
+        let result = sample5(1, 1);
+        assert!(expected_result == result, 2);
+
+        let expected_result = 8;
+        let result = sample5(2, 8);
+        assert!(expected_result == result, 3);
+    }
+
+    #[test, expected_failure(arithmetic_error, location = TestAccount::StillSimple)]
+    fun sample5_substraction_overflow_failure_1_test() {
+        let expected_result = 1;
+        let result = sample5(0, 3);
+
+        assert!(expected_result == result, 404);
+    }
+
+    #[test, expected_failure(arithmetic_error, location = TestAccount::StillSimple)]
+    fun sample5_substraction_overflow_failure_2_test() {
+        let expected_result = 4;
+        let result = sample5(6, 0);
+
+        assert!(expected_result == result, 404);
+    }
+
     fun sample6(x: u128, y: u128): u128 {
         return (x + y - x*(y + 2)*x/y)
+    }
+
+    #[test, expected_failure]
+    fun sample6_division_by_zero_failure_test() {
+        assert!(sample6(50, 0) == 0, 0);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun sample6_substraction_overflow_failure_test() {
+        assert!(sample6(50, 5) == 0, 0);
+    }
+
+    #[test]
+    fun sample6_valid_usage_test() {
+        assert!(sample6(2, 4) == 0, 0);
+        assert!(sample6(4, 14) == 0, 0);
+        assert!(sample6(1, 2) == 1, 0);
+        assert!(sample6(0, 2) == 2, 0);
+        assert!(sample6(4, 16) == 2, 0);
     }
 }

--- a/move-mutator/tests/move-assets/simple/sources/Sum.move
+++ b/move-mutator/tests/move-assets/simple/sources/Sum.move
@@ -7,4 +7,12 @@ module TestAccount::Sum {
 
         sum_r
     }
+
+    #[test]
+    fun sum_test() {
+        assert!(sum(2, 2) == 4, 0);
+        assert!(sum(0, 5) == 5, 0);
+        assert!(sum(100, 0) == 100, 0);
+        assert!(sum(0, 0) == 0, 0);
+    }
 }


### PR DESCRIPTION
These projects will be used to conduct testing with the `move-mutation-test` prototype tool that is going to be delivered in another PR.
Early info:
 - running the tool against some projects takes a lot of time, e.g. 18 minutes for the project `simple`.