### PR TITLE
feat(mutator): add include-functions filter CLI arg 

### DIFF
--- a/move-mutator/src/cli.rs
+++ b/move-mutator/src/cli.rs
@@ -2,6 +2,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::configuration::FunctionFilter;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, str::FromStr};
@@ -15,24 +16,35 @@ pub struct CLIOptions {
     /// The paths to the Move sources.
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
+
     /// Module names to be mutated.
     #[clap(long, value_parser, default_value = "all")]
     pub mutate_modules: ModuleFilter,
+
+    /// Function names to be mutated.
+    #[clap(short = 'f', long, value_parser, default_value = "all")]
+    pub mutate_functions: FunctionFilter,
+
     /// The path where to put the output files.
     #[clap(long, short, value_parser)]
     pub out_mutant_dir: Option<PathBuf>,
+
     /// Indicates if mutants should be verified and made sure mutants can compile.
     #[clap(long, default_value = "false")]
     pub verify_mutants: bool,
+
     /// Indicates if the output files should be overwritten.
     #[clap(long, short, default_value = "false")]
     pub no_overwrite: bool,
+
     /// Name of the filter to use for downsampling. Downsampling reduces the amount of mutants to the desired amount.
     #[clap(long, hide = true)]
     pub downsample_filter: Option<String>,
+
     /// Remove averagely given percentage of mutants. See the doc for more details.
     #[clap(long)]
     pub downsampling_ratio_percentage: Option<usize>,
+
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
@@ -46,6 +58,7 @@ impl Default for CLIOptions {
         Self {
             move_sources: vec![],
             mutate_modules: ModuleFilter::All,
+            mutate_functions: FunctionFilter::All,
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: false,
             no_overwrite: false,
@@ -71,7 +84,7 @@ impl FromStr for ModuleFilter {
         match s {
             "all" => Ok(ModuleFilter::All),
             _ => Ok(ModuleFilter::Selected(
-                s.split(',').map(String::from).collect(),
+                s.split(&[';', '-', ',']).map(String::from).collect(),
             )),
         }
     }

--- a/move-mutator/src/main.rs
+++ b/move-mutator/src/main.rs
@@ -13,10 +13,10 @@ use std::path::PathBuf;
 #[derive(Default, Parser, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Opts {
-    /// The path where to put the output files.
+    /// The path to the target Move package.
     #[clap(long, short, value_parser)]
     pub package_path: Option<PathBuf>,
-    /// Command line options for mutator
+    /// Command line options for mutator.
     #[clap(flatten)]
     pub cli_options: CLIOptions,
     /// The build configuration for the Move package.

--- a/move-spec-test/src/lib.rs
+++ b/move-spec-test/src/lib.rs
@@ -50,7 +50,7 @@ pub fn run_spec_test(
     package_path: &Path,
 ) -> anyhow::Result<()> {
     // We need to initialize logger using try_init() as it might be already initialized in some other tool
-    // (e.g. spec-test). If we use init() instead, we will get an abort.
+    // (e.g. move-mutator). If we use init() instead, we will get an abort.
     let _ = pretty_env_logger::try_init();
 
     // Check if package is correctly structured.

--- a/move-spec-test/src/main.rs
+++ b/move-spec-test/src/main.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 #[derive(Default, Parser, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Opts {
-    /// The path where to put the output files.
+    /// The path to the target Move package.
     #[clap(long, short, value_parser)]
     pub package_path: Option<PathBuf>,
     /// Command line options for specification tester


### PR DESCRIPTION
Adds a CLI argument that allows mutating only specified functions only.
This feature will be used a lot within the `move-mutation-test` tool.