### PR TITLE
refactor: optimize compile speed (skip fetch deps)

### DIFF
--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -2,9 +2,9 @@ name: Basic check and lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop-m1 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop-m1 ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/move-mutator/tests/move-assets/basic_coin/Move.toml
+++ b/move-mutator/tests/move-assets/basic_coin/Move.toml
@@ -2,9 +2,10 @@
 name = "basic_coin"
 version = "0.0.0"
 
-[dependencies]
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
 
 [addresses]
-std =  "0x1"
 CafeAccount = "0xCAFE"

--- a/move-mutator/tests/move-assets/breakcontinue/Move.toml
+++ b/move-mutator/tests/move-assets/breakcontinue/Move.toml
@@ -2,9 +2,10 @@
 name = "breakcontinue"
 version = "0.0.0"
 
-[dependencies]
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
 
 [addresses]
-std =  "0x1"
 TestAccount = "0xCAFE"

--- a/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
+++ b/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
@@ -2,9 +2,10 @@
 name = "p1"
 version = "0.0.0"
 
-[dependencies]
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
 
 [addresses]
-std =  "0x1"
 TestAccount = "0xCAFE2"

--- a/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
+++ b/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
@@ -4,9 +4,12 @@ version = "0.0.0"
 
 [dependencies]
 p1 = { local = "../p1" }
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
 
 [addresses]
-std =  "0x1"
 CafeAccount = "0xCAFE"
 TestAccount = "0xCAFE2"

--- a/move-mutator/tests/move-assets/simple/Move.toml
+++ b/move-mutator/tests/move-assets/simple/Move.toml
@@ -2,9 +2,10 @@
 name = "simple"
 version = "0.0.0"
 
-[dependencies]
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
 
 [addresses]
-std =  "0x1"
 TestAccount = "0xCAFE"


### PR DESCRIPTION
Optimization takes use of the `skip-fetch-latest-git-deps` compilation flag.
Regardless of this flag, by default - if no deps are found in the
`/Users/$USER/.move` directory (a cache folder for Move packages)
the missing packages will be downloaded there.

But if the cache exists, then the `skip-fetch-latest-git-deps` flag can
be used to skip checking whether those cached Move packages ought to be
updated.

In this PR - for the first compilation step (checking that the original
tests are working fine), we disable that flag and ensure we get the
latest Move packages.
Then, for all subsequent compilations (mutant generation and running
tests on those mutants), the tool enables that flag since it doesn't
make much sense to check the latest deps repeatedly - checking it only
once when the tool is started, it should be good enough.

**Note: there is a x5 compilation speed increase here.**

---
Additional PR is included here:

[chore: switch to aptos stdlib in tests](https://github.com/eigerco/move-spec-testing/commit/87d01c25d4aca9f5095900726d73f969bb09b53b)

- till now, we used Stdlib from the `move` repo:
```
MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
```

- the right approach is to use aptos stdlib:
```
[dependencies.AptosStdlib]
git = 'https://github.com/aptos-labs/aptos-core.git'
rev = 'main'
subdir = 'aptos-move/framework/aptos-stdlib'
```