### PR TITLE
feat(mutation-test): add rayon for concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7292,19 +7292,18 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "a231296ca742e418c43660cb68e082486ff2538e8db432bc818580f3965025ed"
 dependencies = [
- "libc",
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "fcb44a01837a858d47e5a630d2ccf304c8efcc4b83b8f9f75b7a9ee4fcc6e57d"
 dependencies = [
  "cc",
  "libc",
@@ -7904,6 +7903,7 @@ dependencies = [
  "move-unit-test",
  "move-vm-runtime",
  "pretty_env_logger",
+ "rayon",
  "serde",
  "serde_json",
  "tabled",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ move-vm-runtime = { git = "https://github.com/aptos-labs/aptos-core.git" }
 num-traits = "0.2"
 pretty_env_logger = "0.5"
 rand = "0.8"
+rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tabled = "0.16"

--- a/move-mutation-test/Cargo.toml
+++ b/move-mutation-test/Cargo.toml
@@ -31,6 +31,7 @@ move-package = { workspace = true }
 move-unit-test = { workspace = true }
 move-vm-runtime = { workspace = true }
 pretty_env_logger = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tabled = { workspace = true }

--- a/move-mutation-test/src/report.rs
+++ b/move-mutation-test/src/report.rs
@@ -9,6 +9,40 @@ use std::{
 };
 use tabled::{builder::Builder, settings::Style};
 
+/// A file difference that identifies mutants.
+pub type FileDiff = String;
+
+/// The final status of the mutant after running the tests on it.
+#[derive(Debug)]
+pub enum MutantStatus {
+    /// Killed mutant.
+    Killed,
+    /// Alive mutant containing the file difference.
+    Alive(FileDiff),
+}
+
+/// This struct represents a report single mutation test.
+#[derive(Debug)]
+pub struct MiniReport {
+    /// The original file name.
+    pub original_file: PathBuf,
+    /// Qualified name for the function using the 'module::function' syntax.
+    pub qname: String,
+    /// Mutant status after testing it.
+    pub mutant_status: MutantStatus,
+}
+
+impl MiniReport {
+    /// Create a new [`MiniReport`].
+    pub fn new(original_file: PathBuf, qname: String, mutant_status: MutantStatus) -> Self {
+        Self {
+            original_file,
+            qname,
+            mutant_status,
+        }
+    }
+}
+
 /// This struct represents a report of the mutation testing.
 /// It contains the list of entries, where each entry is a file and the number of mutants tested
 /// and killed in that file (in form of a `ReportEntry` structure).


### PR DESCRIPTION
Optimization feature adding rayon into the `move-mutation-test` to
ensure that test execution on each mutant is done in parallel.
Execution speed is between x2 and x3 times improved here.