### PR TITLE
chore: improve the binary_operator_swap op

### DIFF
--- a/move-mutator/src/operators/binary_swap.rs
+++ b/move-mutator/src/operators/binary_swap.rs
@@ -104,10 +104,10 @@ impl MutationOperator for BinarySwap {
 
         let mut mutated_source = source.to_string();
         let mut op = right_str.to_owned();
-        // Add one whitespace after the left operator
+        // Add one whitespace after the left operator.
         op.push(' ');
         op.push_str(binop_str);
-        // Add one whitespace after the right operator
+        // Add one whitespace after the right operator.
         op.push(' ');
         op.push_str(left_str);
 

--- a/move-mutator/src/report.rs
+++ b/move-mutator/src/report.rs
@@ -252,6 +252,12 @@ impl MutationReport {
     pub fn get_diff(&self) -> &str {
         &self.diff
     }
+
+    /// Return mutations.
+    #[must_use]
+    pub fn get_mutations(&self) -> &Vec<Mutation> {
+        &self.mutations
+    }
 }
 
 #[cfg(test)]

--- a/move-mutator/tests/move-assets/check_swap_operator/Move.toml
+++ b/move-mutator/tests/move-assets/check_swap_operator/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "simple"
+version = "0.0.0"
+
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/move-mutator/tests/move-assets/check_swap_operator/sources/StorageAccess.move
+++ b/move-mutator/tests/move-assets/check_swap_operator/sources/StorageAccess.move
@@ -42,7 +42,7 @@ module 0x42::m2 {
     }
 }
 
-// Info 1: All functions below use binary operators `+`, `*`, `&`, `|`, `==`, `!=`, `^`
+// Info 1: All functions below use binary operators `+`, `*`, `&`, `&&`, `|`, `||`, `==`, `!=`, `^`
 // for which the order doesn't matter.
 //
 // Info 2: Deliberately use funny identation for the sake of the extra test.

--- a/move-mutator/tests/move-assets/check_swap_operator/sources/StorageAccess.move
+++ b/move-mutator/tests/move-assets/check_swap_operator/sources/StorageAccess.move
@@ -1,0 +1,99 @@
+module 0x42::m1 {
+    struct T has copy,key,drop { a: u64 }
+
+    public fun create_t(account: &signer) {
+        let t = T { a: 0 };
+        move_to<T>(account, t);
+    }
+
+    public fun ret_t_ref(a: address): u64 acquires T {
+        let ref = borrow_global<T>(a).a;
+        let retval = ref + 5;
+        retval
+    }
+
+    public fun ret_t_mut_ref(a: address): u64 acquires T {
+        let ref = &mut borrow_global_mut<T>(a).a;
+        *ref = *ref + 1;
+        let retval = *ref + 10;
+        retval
+    }
+}
+
+module 0x42::m2 {
+    public fun borrow_then_borrow_and_modify(a: address): u64 {
+        0x42::m1::ret_t_ref(a) + 0x42::m1::ret_t_mut_ref(a)
+    }
+
+    public fun borrow_then_borrow_and_modify_reversed(a: address): u64 {
+       0x42::m1::ret_t_mut_ref(a) + 0x42::m1::ret_t_ref(a)
+    }
+
+    #[test(arg = @0xC0FFEE)]
+    fun run(arg: signer) {
+        0x42::m1::create_t(&arg);
+        assert!(borrow_then_borrow_and_modify(0x1::signer::address_of(&arg)) == 16, 0);
+    }
+
+    #[test(arg = @0xC0FFEE)]
+    fun run_reverse(arg: signer) {
+        0x42::m1::create_t(&arg);
+        assert!(borrow_then_borrow_and_modify_reversed(0x1::signer::address_of(&arg)) == 17, 0);
+    }
+}
+
+// Info 1: All functions below use binary operators `+`, `*`, `&`, `|`, `==`, `!=`, `^`
+// for which the order doesn't matter.
+//
+// Info 2: Deliberately use funny identation for the sake of the extra test.
+module 0x42::m3 {
+    fun swap_op_should_mutate_once_v1(a: address, b: u64): u64 {
+       0x42::m1::ret_t_mut_ref(a)     * b
+    }
+
+    fun swap_op_should_mutate_once_v2(a: address, b: u64): u64 {
+        b |0x42::m1::ret_t_ref(a)
+    }
+
+    inline fun swap_op_should_mutate_once_v3(a: u32, f: |u32| u32): u32 {
+        // Expect a swap here:
+        a + f(3)
+    }
+
+    inline fun swap_op_should_mutate_seven_times(a: address, b: u64, closure: |u64| bool): u64 {
+       let b1 = false;
+       let b2 = false;
+
+       // Expect no swaps here:
+       if (b1 || b2) return 0;
+       if (b1 &&    b2) return 0;
+       if (b1!= true) return 0;
+
+       // Expect one swap here for each:
+       if (b1 == closure(23)) return 1;
+       if (closure(20 ) !=    closure(23)) return 2;
+       if (!closure(22) &&true) return   3;
+       if (closure(2) || false) return 4;
+
+       // Expect two swaps here:
+       if (b2 !=    (0x42::m1::ret_t_ref(a)==  1)) return 4;
+
+       // One more swap:
+       (b^10) + 0x42::m2::borrow_then_borrow_and_modify_reversed(a)
+    }
+
+    fun swap_op_should_mutate_three_times(a: address, b: u64): u64 {
+       (7 *   (0x42::m1::ret_t_mut_ref(a)+ b)) & 259
+    }
+
+    fun swap_op_should_not_mutate(a: u64, b: u64): u64 {
+       let c = 2 * (a +b);
+       let d = c* (40& (a | b));
+
+       if (c ==d) {
+           c + d
+       } else {
+           d  +c
+       }
+    }
+}


### PR DESCRIPTION
These binary operations have the commutative property:
`+`, `*`, `&`, `&&`, `|`, `||`, `==`, `!=`, `^`

And by default, the mutator shouldn't swap expressions around operators
for these operations.

Except in the case where expressions contain a function or a closure
somewhere in the expression AST tree.
In those cases, the `binary operator swap` should be applied since
functions and closures might affect the values in the expressions
depending on the order of the expressions.

Explore tests under `module 0x42::m2` in the `check_swap_operator`
project under `move-assets` for more info.