### PR TITLE
chore(mutator): improve binary replace operator

### DIFF
--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -2,9 +2,9 @@ name: Basic check and lint
 
 on:
   push:
-    branches: [ main, develop-m1 ]
+    branches: [ main, develop-m1, develop-m2 ]
   pull_request:
-    branches: [ main, develop-m1 ]
+    branches: [ main, develop-m1, develop-m2 ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8097,6 +8097,7 @@ dependencies = [
  "move-model",
  "move-package",
  "move-symbol-pool",
+ "num",
  "num-traits",
  "pretty_env_logger",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ move-prover = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "
 move-symbol-pool = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 move-unit-test = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 move-vm-runtime = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+num = "0.4"
 num-traits = "0.2"
 pretty_env_logger = "0.5"
 rand = "0.8"

--- a/move-mutator/Cargo.toml
+++ b/move-mutator/Cargo.toml
@@ -29,6 +29,7 @@ move-compiler-v2 = { workspace = true }
 move-model = { workspace = true }
 move-package = { workspace = true }
 move-symbol-pool = { workspace = true }
+num = { workspace = true }
 num-traits = { workspace = true }
 pretty_env_logger = { workspace = true }
 rand = { workspace = true }

--- a/move-mutator/src/report.rs
+++ b/move-mutator/src/report.rs
@@ -168,6 +168,18 @@ impl Mutation {
         }
     }
 
+    /// Returns the original value.
+    #[must_use]
+    pub fn get_original_value(&self) -> &str {
+        &self.old_value
+    }
+
+    /// Returns the new value.
+    #[must_use]
+    pub fn get_new_value(&self) -> &str {
+        &self.new_value
+    }
+
     /// Returns the operator name.
     #[must_use]
     pub fn get_operator_name(&self) -> &str {

--- a/move-mutator/tests/move-assets/simple/sources/BinaryReplacement.move
+++ b/move-mutator/tests/move-assets/simple/sources/BinaryReplacement.move
@@ -1,0 +1,84 @@
+module TestAccount::BinaryReplacement {
+    fun is_x_eq_to_zero(x: u64): bool {
+        if (x == 0)
+            return true;
+
+        false
+    }
+
+    fun is_zero_eq_to_x(x: u64): bool {
+        if (0 == x)
+            return true;
+
+        false
+    }
+
+    #[test]
+    fun test_is_zero() {
+        assert!(is_x_eq_to_zero(0), 0);
+        assert!(!is_x_eq_to_zero(1), 0);
+        assert!(is_zero_eq_to_x(0), 0);
+        assert!(!is_zero_eq_to_x(2), 0);
+    }
+
+    // If we try to combine above two functions into one function,
+    // the move-mutation-test won't be able to kill these mutants:
+    // and that would be a clear indication of silly code that has
+    // one identical reduntant check.
+    fun is_zero_silly_code(x: u64): bool {
+        if (0 == x)
+            return true;
+
+        // Another check which does the same is silly:
+        if (x == 0)
+            return true;
+
+        false
+    }
+
+    #[test]
+    fun test_is_zero_silly() {
+        assert!(is_zero_silly_code(0), 0);
+        assert!(!is_zero_silly_code(1), 0);
+    }
+
+    fun is_x_neq_to_zero(x: u64): bool {
+        x != 0
+    }
+
+    #[test]
+    fun test_is_x_neq_to_zero() {
+        assert!(is_x_neq_to_zero(3), 0);
+        assert!(!is_x_neq_to_zero(0), 0);
+    }
+
+    fun is_zero_neq_to_x(x: u64): bool {
+        0 != x
+    }
+
+    #[test]
+    fun test_is_zero_neq_to_x() {
+        assert!(is_zero_neq_to_x(3), 0);
+        assert!(!is_zero_neq_to_x(0), 0);
+    }
+
+    fun is_x_gt_zero(x: u64): bool {
+        x > 0
+    }
+
+    #[test]
+    fun test_is_x_gt_zero() {
+        assert!(is_x_gt_zero(4), 0);
+        assert!(!is_x_gt_zero(0), 0);
+    }
+
+    fun is_zero_lt_x(x: u64): bool {
+        0 < x
+    }
+
+    #[test]
+    fun test_is_zero_lt_x() {
+        assert!(is_zero_lt_x(3), 0);
+        assert!(!is_zero_lt_x(0), 0);
+    }
+}


### PR DESCRIPTION
To avoid false-positive results with move-spec-test and move-mutation-test, the binary replacement operator has been improved with the following rules:

```
x == 0 should never mutate to x <= 0
0 == x should never mutate to 0 => x
The reverse is not checked: x <= 0 or 0 >= 0 since such code indicates logic error.

x != 0 should never mutate to x > 0
0 != x should never mutate to 0 < x
x > 0 should never mutate to x != 0
0 < x should never mutate to 0 != x
```