### PR TITLE
feat: apply coverage file for specific mutants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -37,12 +37,6 @@ checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -144,7 +138,7 @@ checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -247,7 +241,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos"
 version = "4.2.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -273,7 +267,7 @@ dependencies = [
  "aptos-move-debugger",
  "aptos-network-checker",
  "aptos-node",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-storage-interface",
@@ -289,13 +283,13 @@ dependencies = [
  "bcs 0.1.4",
  "bollard",
  "chrono",
- "clap 4.5.18",
+ "clap 4.5.19",
  "clap_complete",
  "colored",
  "dashmap 5.5.3",
  "diesel",
  "diesel-async",
- "dirs",
+ "dirs 5.0.1",
  "futures",
  "hex",
  "itertools 0.13.0",
@@ -313,6 +307,7 @@ dependencies = [
  "move-ir-types",
  "move-model",
  "move-package",
+ "move-prover-boogie-backend",
  "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
@@ -327,6 +322,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "server-framework",
+ "set_env",
  "shadow-rs",
  "tempfile",
  "thiserror",
@@ -342,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -355,7 +351,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -365,7 +361,7 @@ dependencies = [
 [[package]]
 name = "aptos-admin-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -375,7 +371,7 @@ dependencies = [
  "aptos-logger",
  "aptos-runtimes",
  "aptos-storage-interface",
- "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-system-utils 0.1.0 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "aptos-types",
  "bcs 0.1.4",
  "http 0.2.12",
@@ -388,7 +384,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -402,7 +398,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -442,7 +438,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -472,7 +468,7 @@ dependencies = [
 [[package]]
 name = "aptos-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-backup-service",
@@ -497,7 +493,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "bytes",
- "clap 4.5.18",
+ "clap 4.5.19",
  "csv",
  "futures",
  "itertools 0.13.0",
@@ -522,7 +518,7 @@ dependencies = [
 [[package]]
 name = "aptos-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-db",
@@ -544,7 +540,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "hex",
@@ -553,7 +549,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -562,7 +558,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -597,14 +593,14 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "dashmap 5.5.3",
  "itertools 0.13.0",
  "jemallocator",
@@ -618,7 +614,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "futures",
  "rustversion",
@@ -628,7 +624,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "shadow-rs",
 ]
@@ -636,7 +632,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -650,7 +646,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -661,22 +657,22 @@ dependencies = [
 [[package]]
 name = "aptos-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anstyle",
- "clap 4.5.18",
+ "clap 4.5.19",
  "clap_complete",
 ]
 
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -688,7 +684,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -718,7 +714,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -761,7 +757,7 @@ dependencies = [
  "bytes",
  "chrono",
  "claims",
- "clap 4.5.18",
+ "clap 4.5.19",
  "dashmap 5.5.3",
  "enum_dispatch",
  "fail",
@@ -796,7 +792,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -811,7 +807,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -839,7 +835,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -851,7 +847,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +900,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -914,7 +910,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -945,7 +941,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -971,7 +967,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1013,17 +1009,19 @@ dependencies = [
  "serde",
  "static_assertions",
  "status-line",
+ "tokio",
 ]
 
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-db-indexer-schemas",
  "aptos-logger",
+ "aptos-metrics-core",
  "aptos-resource-viewer",
  "aptos-rocksdb-options",
  "aptos-schemadb",
@@ -1033,12 +1031,13 @@ dependencies = [
  "bytes",
  "dashmap 5.5.3",
  "move-core-types",
+ "once_cell",
 ]
 
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1055,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1087,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1126,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1137,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1146,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1162,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1195,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1210,7 +1209,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "crossbeam-channel",
  "ctrlc",
  "dashmap 5.5.3",
@@ -1225,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1247,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1267,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1280,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "thiserror",
 ]
@@ -1288,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1298,7 +1297,7 @@ dependencies = [
  "aptos-sdk",
  "async-trait",
  "captcha",
- "clap 4.5.18",
+ "clap 4.5.19",
  "deadpool-redis",
  "enum_dispatch",
  "futures",
@@ -1316,13 +1315,12 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
- "url",
 ]
 
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1336,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1359,7 +1357,7 @@ dependencies = [
  "blake2-rfc",
  "bulletproofs",
  "byteorder",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan-reporting",
  "curve25519-dalek-ng",
  "either",
@@ -1405,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "either",
  "move-core-types",
@@ -1414,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1429,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1449,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1462,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "aptos-genesis"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1487,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "aptos-github-client"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-proxy",
  "serde",
@@ -1499,17 +1497,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1521,7 +1519,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1547,14 +1545,14 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-system-utils 0.1.0 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "async-trait",
  "backtrace",
- "clap 4.5.18",
+ "clap 4.5.19",
  "prometheus",
  "serde",
  "serde_yaml 0.8.26",
@@ -1569,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1599,11 +1597,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1684,12 +1682,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -1715,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1743,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1780,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1795,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1805,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1849,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1862,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1872,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1896,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1909,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1949,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1962,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -1973,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1982,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-debugger"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
@@ -1997,7 +1995,7 @@ dependencies = [
  "aptos-vm-logging",
  "aptos-vm-types",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "itertools 0.13.0",
  "regex",
  "reqwest",
@@ -2008,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2047,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2068,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2085,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2102,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2147,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-benchmark"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-config",
  "aptos-logger",
@@ -2167,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2190,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -2198,7 +2196,7 @@ dependencies = [
  "aptos-logger",
  "aptos-network",
  "aptos-types",
- "clap 4.5.18",
+ "clap 4.5.19",
  "futures",
  "serde",
  "tokio",
@@ -2207,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2232,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "aptos-node"
 version = "0.0.0-main"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-admin-service",
@@ -2284,7 +2282,7 @@ dependencies = [
  "aptos-validator-transaction-pool",
  "aptos-vm",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "either",
  "fail",
  "futures",
@@ -2304,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2315,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2331,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2341,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2353,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2366,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2391,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-bounded-executor",
  "aptos-build-info",
@@ -2417,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2429,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2455,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2465,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -2489,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "ipnet",
 ]
@@ -2497,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2508,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -2530,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2544,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2567,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2576,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "rayon",
  "tokio",
@@ -2585,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-config",
  "aptos-consensus-types",
@@ -2609,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2626,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2645,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2667,12 +2665,12 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "heck 0.4.1",
  "move-core-types",
  "once_cell",
@@ -2685,11 +2683,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2703,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2724,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2735,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2746,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -2779,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2806,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -2817,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -2829,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2858,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -2874,10 +2872,10 @@ dependencies = [
 [[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
- "aptos-profiler 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
+ "aptos-profiler 0.1.0 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
  "async-mutex",
  "http 0.2.12",
  "hyper 0.14.30",
@@ -2914,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2932,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2971,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -2984,7 +2982,7 @@ dependencies = [
  "base64 0.13.1",
  "bcs 0.1.4",
  "chrono",
- "clap 4.5.18",
+ "clap 4.5.19",
  "debug-ignore",
  "flate2",
  "futures",
@@ -3011,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3020,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3033,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -3043,13 +3041,18 @@ dependencies = [
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "ark-bn254",
+ "ark-ec",
  "ark-ff",
  "ark-groth16",
+ "ark-relations",
  "ark-serialize",
+ "ark-std",
  "arr_macro",
  "base64 0.13.1",
  "bcs 0.1.4",
  "bytes",
+ "dashmap 5.5.3",
+ "derivative",
  "fixed",
  "fxhash",
  "hashbrown 0.14.5",
@@ -3090,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 
 [[package]]
 name = "aptos-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -3116,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3129,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3145,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3196,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3218,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3233,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3255,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -3551,14 +3554,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -3567,13 +3570,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3584,7 +3587,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3606,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -3684,7 +3687,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -3841,7 +3844,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4045,7 +4048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "serde",
 ]
 
@@ -4197,9 +4200,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "jobserver",
  "libc",
@@ -4350,9 +4353,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -4360,9 +4363,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4373,11 +4376,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.29"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8937760c3f4c60871870b8c3ee5f9b30771f792a7045c48bcbba999d7d6b3b8e"
+checksum = "74a01f4f9ee6c066d42a1c8dedf0dcddad16c72a8981a309d6398de3a75b0c39"
 dependencies = [
- "clap 4.5.18",
+ "clap 4.5.19",
 ]
 
 [[package]]
@@ -4389,7 +4392,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4975,7 +4978,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5013,7 +5016,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5024,7 +5027,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5118,7 +5121,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5178,7 +5181,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5199,7 +5202,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5209,7 +5212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5222,7 +5225,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5272,7 +5275,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5292,7 +5295,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5333,11 +5336,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -5348,6 +5360,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5556,7 +5579,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5785,12 +5808,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -5842,7 +5865,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5940,7 +5963,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6114,8 +6137,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -6284,7 +6307,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -6303,7 +6326,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -6368,6 +6391,12 @@ dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "headers"
@@ -6623,9 +6652,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -6820,7 +6849,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -6919,12 +6948,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -6954,12 +6983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.11",
- "clap 4.5.18",
+ "clap 4.5.19",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 6.1.0",
  "env_logger 0.11.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "is-terminal",
  "itoa",
  "log",
@@ -7284,7 +7313,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.6",
+ "redox_syscall 0.5.7",
 ]
 
 [[package]]
@@ -7432,18 +7461,18 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a231296ca742e418c43660cb68e082486ff2538e8db432bc818580f3965025ed"
+checksum = "4d1febb2b4a79ddd1980eede06a8f7902197960aa0383ffcfdd62fe723036725"
 dependencies = [
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.11.0"
+version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb44a01837a858d47e5a630d2ccf304c8efcc4b83b8f9f75b7a9ee4fcc6e57d"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -7581,21 +7610,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
- "simd-adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -7652,7 +7672,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7664,7 +7684,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7681,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7696,12 +7716,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7716,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "once_cell",
  "quote",
@@ -7726,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7738,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -7752,10 +7772,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "crossterm 0.26.1",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -7767,10 +7787,10 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan-reporting",
  "colored",
  "move-binary-format",
@@ -7797,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "difference",
@@ -7814,11 +7834,11 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan-reporting",
  "hex",
  "move-binary-format",
@@ -7840,12 +7860,12 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan-reporting",
  "ethnum",
  "flexi_logger",
@@ -7874,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7899,11 +7919,11 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan",
  "colored",
  "move-binary-format",
@@ -7918,10 +7938,10 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -7935,10 +7955,10 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan",
  "codespan-reporting",
  "itertools 0.13.0",
@@ -7954,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -7966,11 +7986,11 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.18",
+ "clap 4.5.19",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -7982,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -8000,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "hex",
@@ -8013,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -8026,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "codespan",
@@ -8059,7 +8079,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-types",
  "aptos-vm",
- "clap 4.5.18",
+ "clap 4.5.19",
  "log",
  "move-cli",
  "move-command-line-common",
@@ -8069,11 +8089,10 @@ dependencies = [
  "move-package",
  "move-unit-test",
  "move-vm-runtime",
+ "mutator-common",
  "pretty_env_logger",
  "rayon",
  "serde",
- "serde_json",
- "tabled",
  "tempfile",
  "termcolor",
 ]
@@ -8083,7 +8102,7 @@ name = "move-mutator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan",
  "codespan-reporting",
  "diffy",
@@ -8094,6 +8113,7 @@ dependencies = [
  "move-command-line-common",
  "move-compiler",
  "move-compiler-v2",
+ "move-coverage",
  "move-model",
  "move-package",
  "move-symbol-pool",
@@ -8111,10 +8131,10 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "colored",
  "itertools 0.13.0",
  "move-abigen",
@@ -8145,11 +8165,11 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "atty",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan-reporting",
  "itertools 0.13.0",
  "log",
@@ -8172,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8201,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -8218,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "hex",
@@ -8233,16 +8253,15 @@ name = "move-spec-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.18",
+ "clap 4.5.19",
  "log",
  "move-model",
  "move-mutator",
  "move-package",
  "move-prover",
+ "mutator-common",
  "pretty_env_logger",
  "serde",
- "serde_json",
- "tabled",
  "tempfile",
  "termcolor",
 ]
@@ -8250,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -8270,7 +8289,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "hex",
@@ -8293,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "once_cell",
  "serde",
@@ -8302,7 +8321,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "better_any",
  "bytes",
@@ -8317,11 +8336,11 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "better_any",
- "clap 4.5.18",
+ "clap 4.5.19",
  "codespan-reporting",
  "colored",
  "itertools 0.13.0",
@@ -8346,7 +8365,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "better_any",
  "bytes",
@@ -8362,7 +8381,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "serde",
  "sha3 0.9.1",
- "tracing",
  "triomphe",
  "typed-arena",
 ]
@@ -8370,7 +8388,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8386,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#5ad601cc4bb5adeb086721a4d57ca3014119c77f"
+source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -8434,6 +8452,16 @@ dependencies = [
  "spin 0.9.8",
  "tokio",
  "version_check",
+]
+
+[[package]]
+name = "mutator-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tabled",
 ]
 
 [[package]]
@@ -8748,9 +8776,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -8787,7 +8818,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -8962,7 +8993,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.6",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -8998,7 +9029,7 @@ dependencies = [
  "parquet",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -9020,7 +9051,7 @@ dependencies = [
  "ciborium",
  "coset",
  "data-encoding",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -9156,7 +9187,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -9187,7 +9218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -9245,7 +9276,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -9339,15 +9370,15 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -9375,7 +9406,7 @@ dependencies = [
  "quick-xml 0.32.0",
  "regex",
  "rfc7239",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -9401,7 +9432,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -9413,7 +9444,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "futures-util",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "mime",
  "num-traits",
  "poem",
@@ -9436,13 +9467,13 @@ source = "git+https://github.com/poem-web/poem.git?rev=809b2816d3504beeba140fef3
 dependencies = [
  "darling",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "mime",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.79",
  "thiserror",
 ]
 
@@ -9460,9 +9491,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "poseidon-ark"
@@ -9703,7 +9734,7 @@ dependencies = [
  "bitflags 2.6.0",
  "canonical_json",
  "chrono",
- "clap 4.5.18",
+ "clap 4.5.19",
  "diesel",
  "diesel-async",
  "diesel_migrations",
@@ -9796,7 +9827,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -9813,7 +9844,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -9873,7 +9904,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -10184,9 +10215,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -10219,19 +10250,19 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -10245,13 +10276,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -10262,9 +10293,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -10614,7 +10645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -10631,19 +10662,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -10927,7 +10957,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -10936,7 +10966,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -10962,7 +10992,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -10988,15 +11018,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11006,14 +11036,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -11034,7 +11064,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -11050,7 +11080,7 @@ dependencies = [
  "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=202bdccff2b2d333a385ae86a4fcf23e89da9f62)",
  "async-trait",
  "backtrace",
- "clap 4.5.18",
+ "clap 4.5.19",
  "prometheus",
  "serde",
  "serde_yaml 0.8.26",
@@ -11060,6 +11090,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "warp",
+]
+
+[[package]]
+name = "set_env"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51864fb62fd09b8a7d931a11832bfbbda5297425cfc9ce04b54bc86c945c58eb"
+dependencies = [
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -11520,7 +11559,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -11571,9 +11610,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11688,9 +11727,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -11732,12 +11771,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix 0.38.37",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11793,7 +11832,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -11948,7 +11987,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -12095,7 +12134,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -12108,7 +12147,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -12169,7 +12208,7 @@ dependencies = [
  "pin-project",
  "prost 0.12.6",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -12246,7 +12285,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -12410,7 +12449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -12445,9 +12484,9 @@ dependencies = [
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -12543,9 +12582,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -12570,9 +12609,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -12779,7 +12818,7 @@ dependencies = [
  "multer 2.1.0",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -12832,7 +12871,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -12866,7 +12905,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -12879,9 +12918,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -12936,7 +12975,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.6",
+ "redox_syscall 0.5.7",
  "wasite",
  "web-sys",
 ]
@@ -12949,9 +12988,9 @@ checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "wildmatch"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3928939971918220fed093266b809d1ee4ec6c1a2d72692ff6876898f3b16c19"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
 
 [[package]]
 name = "winapi"
@@ -13337,7 +13376,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -13357,7 +13396,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ rust-version = "1.78.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
-aptos = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-aptos-framework = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-aptos-gas-schedule = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-aptos-types = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-aptos-vm = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+# temporary use my fork since we need this commit:
+# https://github.com/Rqnsom/aptos-core/commit/2dbeacf7fe0d8e37aa98effd32cda8d40daf0502
+aptos = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+aptos-framework = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+aptos-gas-schedule = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+aptos-types = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+aptos-vm = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
 clap = { version = "4.5", features = ["derive"] }
 codespan = "0.11"
 codespan-reporting = "0.11"
@@ -34,17 +36,18 @@ either = "1.9"
 fixed = "= 1.25.1" # required by aptos deps
 itertools = "0.13"
 log = "0.4"
-move-cli = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-command-line-common = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-compiler = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-compiler-v2 = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-model = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-cli = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-command-line-common = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-compiler = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-compiler-v2 = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-coverage = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-model = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
 move-mutator = { path = "move-mutator" }
-move-package = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-prover = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-symbol-pool = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-unit-test = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-move-vm-runtime = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-package = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-prover = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-symbol-pool = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-unit-test = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-vm-runtime = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
 num = "0.4"
 mutator-common = { path = "mutator-common" }
 num-traits = "0.2"

--- a/move-mutation-test/src/cli.rs
+++ b/move-mutation-test/src/cli.rs
@@ -38,11 +38,15 @@ pub struct CLIOptions {
 
 /// This function creates a mutator CLI options from the given mutation-test options.
 #[must_use]
-pub fn create_mutator_options(options: &CLIOptions) -> move_mutator::cli::CLIOptions {
+pub fn create_mutator_options(
+    options: &CLIOptions,
+    apply_coverage: bool,
+) -> move_mutator::cli::CLIOptions {
     move_mutator::cli::CLIOptions {
         mutate_functions: options.mutate_functions.clone(),
         mutate_modules: options.mutate_modules.clone(),
         configuration_file: options.mutator_conf.clone(),
+        apply_coverage,
         // To run tests, compilation must succeed
         verify_mutants: true,
         ..Default::default()
@@ -64,7 +68,7 @@ pub fn check_mutator_output_path(options: &move_mutator::cli::CLIOptions) -> Opt
 
 /// The configuration options for running the tests.
 // Info: this set struct is based on TestPackage in `aptos-core/crates/aptos/src/move_tool/mod.rs`.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct TestBuildConfig {
     /// Options for compiling a move package dir.
     // We might move some options out and have our own option struct here - not all options are
@@ -83,12 +87,10 @@ pub struct TestBuildConfig {
     /// A boolean value to skip warnings.
     #[clap(long)]
     pub ignore_compile_warnings: bool,
-    // TODO: There is no sense in enabling coverage - we'll have another option in the future
-    // 'use-coverage-data' or something like that - that is going to be passed to the mutator
-    // tool
-    ///// Collect coverage information for later use with the various `aptos move coverage` subcommands
-    //#[clap(long = "coverage")]
-    //pub compute_coverage: bool,
+
+    /// Compute and then use unit test computed coverage to generate mutants only for covered code.
+    #[clap(long = "coverage")]
+    pub apply_coverage: bool,
 }
 
 impl TestBuildConfig {
@@ -105,6 +107,12 @@ impl TestBuildConfig {
             language_version: self.move_pkg.language_version,
             experiments: experiments_from_opt_level(&self.move_pkg.optimize),
         }
+    }
+
+    pub fn disable_coverage(&self) -> Self {
+        let mut cfg = self.clone();
+        cfg.apply_coverage = false;
+        cfg
     }
 }
 
@@ -141,7 +149,9 @@ mod tests {
             mutator_conf: Some(PathBuf::from("path/to/mutator/conf")),
             ..Default::default()
         };
-        let mutator_options = create_mutator_options(&options);
+
+        let no_apply_coverage = false;
+        let mutator_options = create_mutator_options(&options, no_apply_coverage);
 
         assert_eq!(mutator_options.mutate_modules, options.mutate_modules);
         assert_eq!(mutator_options.configuration_file, options.mutator_conf);

--- a/move-mutation-test/src/mutation_test.rs
+++ b/move-mutation-test/src/mutation_test.rs
@@ -47,8 +47,6 @@ pub(crate) fn run_tests<W: WriteColor + Send>(
     let natives = aptos_debug_natives(NativeGasParameters::zeros(), MiscGasParameters::zeros());
     let cost_table = None;
     let gas_limit = None; // unlimited.
-                          // TODO(M2): Add special handling for the coverage computation.
-    let compute_coverage = false;
 
     let result = move_cli::base::test::run_move_unit_tests(
         package_path,
@@ -75,7 +73,7 @@ pub(crate) fn run_tests<W: WriteColor + Send>(
         aptos_test_feature_flags_genesis(),
         gas_limit,
         cost_table,
-        compute_coverage,
+        cfg.apply_coverage,
         &mut error_writer,
     )
     .map_err(|err| Error::msg(format!("failed to run unit tests: {err:#}")))?;

--- a/move-mutator/Cargo.toml
+++ b/move-mutator/Cargo.toml
@@ -27,6 +27,7 @@ log = { workspace = true }
 move-command-line-common = { workspace = true }
 move-compiler = { workspace = true }
 move-compiler-v2 = { workspace = true }
+move-coverage = { workspace = true }
 move-model = { workspace = true }
 move-package = { workspace = true }
 move-symbol-pool = { workspace = true }

--- a/move-mutator/src/cli.rs
+++ b/move-mutator/src/cli.rs
@@ -48,6 +48,10 @@ pub struct CLIOptions {
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
+
+    /// Use the unit test coverage report to generate mutants for source code with unit test coverage.
+    #[clap(long = "coverage")]
+    pub apply_coverage: bool,
 }
 
 impl Default for CLIOptions {
@@ -62,6 +66,7 @@ impl Default for CLIOptions {
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: false,
             no_overwrite: false,
+            apply_coverage: false,
             downsample_filter: None,
             downsampling_ratio_percentage: None,
             configuration_file: None,

--- a/move-mutator/src/configuration.rs
+++ b/move-mutator/src/configuration.rs
@@ -2,7 +2,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli::CLIOptions;
+use crate::{cli::CLIOptions, coverage::Coverage};
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
@@ -15,9 +15,8 @@ pub enum FileType {
     JSON,
     TOML,
 }
-
 /// Mutator configuration for the Move project.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Configuration {
     /// Main project options. It's the same as the CLI options.
     pub project: CLIOptions,
@@ -27,6 +26,9 @@ pub struct Configuration {
     pub mutation: Option<MutationConfig>,
     /// Configuration for the individual files. (optional).
     pub individual: Vec<FileConfiguration>,
+    #[serde(skip)]
+    /// Coverage report where the optional unit test coverage data is stored.
+    pub(crate) coverage: Coverage,
 }
 
 impl Configuration {
@@ -38,6 +40,8 @@ impl Configuration {
             project_path,
             mutation: None,
             individual: vec![],
+            // Coverage is unset by default.
+            coverage: Coverage::default(),
         }
     }
 
@@ -326,10 +330,8 @@ mod tests {
             mutate_functions: FunctionFilter::All,
         };
         let config = Configuration {
-            project: CLIOptions::default(),
-            project_path: None,
-            mutation: None,
             individual: vec![file_config],
+            ..Default::default()
         };
 
         let result = config.get_file_configuration(&PathBuf::from("/unknown/path"));

--- a/move-mutator/src/coverage.rs
+++ b/move-mutator/src/coverage.rs
@@ -1,0 +1,207 @@
+use crate::compiler::compile_package;
+use anyhow::Error;
+use codespan::Span;
+use move_command_line_common::files::FileHash;
+use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule};
+use move_coverage::{
+    coverage_map::CoverageMap,
+    source_coverage::{FunctionSourceCoverage, SourceCoverageBuilder},
+};
+use move_model::model::Loc;
+use move_package::BuildConfig;
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Associated function string.
+type AssociatedFuncStr = String;
+
+/// Contains all uncovered spans in the project.
+#[derive(Debug, Default)]
+pub(crate) struct Coverage {
+    /// List of all uncovered spans for all functions for all modules.
+    all_uncovered_spans: BTreeMap<AssociatedFuncStr, UncoveredSpans>,
+}
+
+impl Coverage {
+    /// Compute coverage for the project.
+    pub(crate) fn compute_coverage(
+        &mut self,
+        build_config: &BuildConfig,
+        package_path: &Path,
+    ) -> anyhow::Result<()> {
+        info!("computing coverage");
+
+        let coverage_map = CoverageMap::from_binary_file(package_path.join(".coverage_map.mvcov"))
+            .map_err(|e| Error::msg(format!("failed to retrieve the coverage map: {e}")))?;
+
+        let mut coverage_config = build_config.clone();
+        coverage_config.test_mode = false;
+        let package = compile_package(coverage_config, package_path)?;
+
+        // We might fetch the same sources multiple times per module, so let's store only one instance.
+        let mut sources = HashMap::<&PathBuf, String>::new();
+
+        let mut modules_and_sources = Vec::<_>::new();
+        for unit in package.root_modules() {
+            if let CompiledUnit::Module(NamedCompiledModule {
+                module, source_map, ..
+            }) = &unit.unit
+            {
+                let src_path = &unit.source_path;
+
+                // Both below cases are very unlikely since this happens just after we compile the package:
+                let file_contents =
+                    sources
+                        .entry(src_path)
+                        .or_insert(fs::read_to_string(src_path).map_err(|e| {
+                            Error::msg(format!(
+                                "source code removed during the tool execution: {e}"
+                            ))
+                        })?);
+                if !source_map.check(file_contents) {
+                    anyhow::bail!("source code changed during the execution");
+                }
+
+                modules_and_sources.push((module, source_map, src_path));
+            }
+        }
+
+        let mut all_uncovered_spans = BTreeMap::new();
+        modules_and_sources
+            .into_iter()
+            .map(|(module, source_map, src_path)| {
+                // This `new` function in `SourceCoverageBuilder` calculates uncovered locations.
+                let scb = SourceCoverageBuilder::new(module, &coverage_map, source_map);
+
+                (module, scb.uncovered_locations, src_path)
+            })
+            .for_each(|(module, uncovered_locations, src_path)| {
+                for (identifer, func_source_coverage) in uncovered_locations {
+                    let first_location = func_source_coverage.uncovered_locations.first();
+
+                    // If not empty, get the uncovered spans for the function.
+                    let uncovered_spans = if let Some(loc) = first_location {
+                        // Can't fail since we already inserted this value earlier above.
+                        let file_contents = sources.get(&src_path).unwrap();
+
+                        let file_hash = loc.file_hash();
+                        UncoveredSpans::new(func_source_coverage, file_hash, file_contents)
+                    } else {
+                        continue;
+                    };
+
+                    let module = module.self_name();
+                    let function = identifer.into_string();
+                    let associated_fn_name = format!("{module}::{function}");
+                    all_uncovered_spans.insert(associated_fn_name, uncovered_spans);
+                }
+            });
+
+        trace!("all uncovered spans: {all_uncovered_spans:?}");
+        self.all_uncovered_spans = all_uncovered_spans;
+        Ok(())
+    }
+
+    /// Check if the location is covered by the unit test.
+    pub(crate) fn check_location(&self, associated_fn_name: String, loc: &Loc) -> bool {
+        let span = loc.span();
+
+        let Some(UncoveredSpans(spans)) = self.all_uncovered_spans.get(&associated_fn_name) else {
+            trace!("location has coverage since {associated_fn_name} has full coverage");
+            return true;
+        };
+
+        for uncovered_span in spans {
+            // Skip all early spans.
+            if span.start() >= uncovered_span.end() {
+                continue;
+            }
+
+            // Check if the span starts earlier than the uncovered span.
+            if uncovered_span.start() > span.start() {
+                break;
+            }
+
+            // If the span goes beyond the uncovered span, we are done here.
+            if uncovered_span.end() < span.end() {
+                break;
+            }
+
+            trace!("{associated_fn_name} has no coverage for the given location");
+            return false;
+        }
+
+        trace!("{associated_fn_name} has coverage for the given location");
+        true
+    }
+}
+
+#[derive(Debug)]
+struct UncoveredSpans(Vec<Span>);
+
+impl UncoveredSpans {
+    /// Create a new [`UncoveredSpans`].
+    fn new(func_src_cov: FunctionSourceCoverage, file_hash: FileHash, file_contents: &str) -> Self {
+        let merged_spans = merge_spans(file_hash, func_src_cov);
+        let optimized_spans = merge_spans_after_removing_whitespaces(merged_spans, file_contents);
+        Self(optimized_spans)
+    }
+}
+
+// There is a similar function in aptos-core with the same name, but that one doesn't merge
+// spans that are next to each other (e.g. spans (0..5] and (5..10]) - but that is not
+// noticeable in their usage for the coverage, so nobody noticed this. We can make an update
+// there maybe and then use a more efficient `merge_spans` function from aptos-core repo.
+/// Efficiently merge spans.
+fn merge_spans(file_hash: FileHash, cov: FunctionSourceCoverage) -> Vec<Span> {
+    cov.uncovered_locations
+        .iter()
+        .filter(|loc| loc.file_hash() == file_hash)
+        .map(|loc| Span::new(loc.start(), loc.end()))
+        .collect::<Vec<_>>()
+        .windows(2)
+        .fold(vec![], |mut acc, spans| {
+            let [curr, next] = spans else { return acc };
+            if curr.end() >= next.start() {
+                acc.push(curr.merge(*next));
+            } else {
+                acc.push(*curr);
+            }
+            acc
+        })
+}
+
+/// Remove all whitespaces between spans and merge spans again.
+fn merge_spans_after_removing_whitespaces(mut spans: Vec<Span>, source_code: &str) -> Vec<Span> {
+    let mut new_spans = Vec::with_capacity(spans.len());
+    let mut curr = spans.remove(0);
+
+    'span_loop: for span in spans {
+        let mut curr_end_index = curr.end().to_usize();
+
+        let src_chars = source_code[curr_end_index..].chars();
+        for next_char in src_chars {
+            if next_char != ' ' {
+                break;
+            }
+
+            // We can safely assume the ' ' char will always have the size of one.
+            curr_end_index += 1;
+
+            // If have whitespaces between these two uncovered spans, let's merge those.
+            if curr_end_index == span.start().to_usize() {
+                curr = curr.merge(span);
+                continue 'span_loop;
+            }
+        }
+
+        new_spans.push(curr);
+        curr = span;
+    }
+
+    new_spans.push(curr);
+    new_spans
+}

--- a/move-mutator/src/lib.rs
+++ b/move-mutator/src/lib.rs
@@ -12,6 +12,7 @@ pub mod compiler;
 mod mutate;
 
 pub mod configuration;
+pub(crate) mod coverage;
 mod mutant;
 mod operator;
 mod operators;
@@ -58,26 +59,31 @@ pub fn run_move_mutator(
     info!(
         "Executed move-mutator with the following options: {options:?} \n config: {config:?} \n package path: {package_path:?}"
     );
+    // TODO: add some sanity checks for provided arguments - e.g. compute_coverage is useless when
+    // `move_sources` is used
 
     // Load configuration from file or create a new one.
-    let mutator_configuration = match options.configuration_file {
+    let mut mutator_configuration = match options.configuration_file {
         Some(path) => Configuration::from_file(path.as_path())?,
         None => Configuration::new(options, Some(package_path.to_owned())),
     };
 
     trace!("Mutator configuration: {mutator_configuration:?}");
 
-    let env = generate_ast(
-        &mutator_configuration,
-        config,
-        mutator_configuration
-            .project_path
-            .as_ref()
-            .unwrap_or(&package_path.to_owned())
-            .as_path(),
-    )?;
+    let package_path = mutator_configuration
+        .project_path
+        .clone()
+        .unwrap_or(package_path.to_owned());
+    let env = generate_ast(&mutator_configuration, config, &package_path)?;
 
-    trace!("Generated AST");
+    info!("Generated AST");
+
+    if mutator_configuration.project.apply_coverage {
+        // This implies additional compilation inside.
+        mutator_configuration
+            .coverage
+            .compute_coverage(config, &package_path)?;
+    }
 
     let mutants = mutate::mutate(&env, &mutator_configuration)?;
     let output_dir = output::setup_output_dir(&mutator_configuration)?;

--- a/move-mutator/src/mutate.rs
+++ b/move-mutator/src/mutate.rs
@@ -164,10 +164,18 @@ fn traverse_function(
             }
 
             // Parse only during the descend phase and when we are not inside the spec block.
-            if !asc && !is_inside_spec {
-                result.extend(parse_expression_and_find_mutants(function, exp_data));
+            if asc || is_inside_spec {
+                return true;
             }
 
+            let fn_loc = function.module_env.env.get_node_loc(exp_data.node_id());
+            let fn_name = function.get_full_name_str();
+            trace!("checking coverage {fn_loc:?} for {fn_name}");
+            if !conf.coverage.check_location(fn_name, &fn_loc) {
+                return true;
+            }
+
+            result.extend(parse_expression_and_find_mutants(function, exp_data));
             true
         });
     };

--- a/move-mutator/tests/basic_tests.rs
+++ b/move-mutator/tests/basic_tests.rs
@@ -35,6 +35,7 @@ fn check_mutator_works_correctly() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -67,6 +68,7 @@ fn check_mutator_verify_mutants_correctly() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -98,6 +100,7 @@ fn check_mutator_fails_on_non_existing_path() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -121,6 +124,7 @@ fn check_mutator_fails_on_non_existing_output_path() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -146,6 +150,7 @@ fn check_mutator_works_with_simple_single_files() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -177,6 +182,7 @@ fn check_mutator_properly_fails_with_single_files_that_require_dep_or_addr_resol
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -206,6 +212,7 @@ fn check_mutator_fails_verify_file_without_package() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -246,6 +253,7 @@ fn check_mutator_cli_filters_functions_properly() {
         downsample_filter: None,
         downsampling_ratio_percentage: None,
         configuration_file: None,
+        apply_coverage: false,
     };
 
     let config = BuildConfig::default();
@@ -305,6 +313,7 @@ fn check_mutator_swap_operator_works_correctly_for_corner_cases() {
             downsample_filter: None,
             downsampling_ratio_percentage: None,
             configuration_file: None,
+            apply_coverage: false,
         };
         let package_path = Path::new("tests/move-assets/check_swap_operator");
 
@@ -368,6 +377,7 @@ fn check_mutator_binary_replacement_operator_works_correctly_for_corner_cases_v1
             downsample_filter: None,
             downsampling_ratio_percentage: None,
             configuration_file: None,
+            apply_coverage: false,
         };
         let package_path = Path::new("tests/move-assets/simple");
 


### PR DESCRIPTION
Added a `--coverage` option to both `move-mutator` and `move-mutation-test` tools.

This flag can be used to generate more specific mutants that target only the source code that has unit test coverage.
This can be useful when the test suite lacks tests.