### PR TITLE
deps(Cargo.toml): replace fork with aptos-core and cargo lock update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -241,7 +241,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos"
 version = "4.2.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -267,7 +267,7 @@ dependencies = [
  "aptos-move-debugger",
  "aptos-network-checker",
  "aptos-node",
- "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-storage-interface",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "aptos-admin-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -371,7 +371,7 @@ dependencies = [
  "aptos-logger",
  "aptos-runtimes",
  "aptos-storage-interface",
- "aptos-system-utils 0.1.0 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "aptos-types",
  "bcs 0.1.4",
  "http 0.2.12",
@@ -384,9 +384,8 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
- "aptos-logger",
  "aptos-types",
  "bcs 0.1.4",
  "claims",
@@ -398,7 +397,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -438,7 +437,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -468,7 +467,7 @@ dependencies = [
 [[package]]
 name = "aptos-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-backup-service",
@@ -518,7 +517,7 @@ dependencies = [
 [[package]]
 name = "aptos-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-db",
@@ -540,7 +539,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "hex",
@@ -549,7 +548,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -558,7 +557,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -593,7 +592,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -614,7 +613,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "futures",
  "rustversion",
@@ -624,7 +623,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "shadow-rs",
 ]
@@ -632,7 +631,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -646,7 +645,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -657,7 +656,7 @@ dependencies = [
 [[package]]
 name = "aptos-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anstyle",
  "clap 4.5.19",
@@ -667,12 +666,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -684,7 +683,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -714,7 +713,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -792,7 +791,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -807,7 +806,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -835,7 +834,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -847,7 +846,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -900,7 +899,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,7 +909,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -941,7 +940,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -967,7 +966,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1015,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1037,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1054,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1086,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1125,7 +1124,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1136,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1145,7 +1144,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1161,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1194,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1224,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1246,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1266,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1279,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "thiserror",
 ]
@@ -1287,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1320,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1334,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1403,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "either",
  "move-core-types",
@@ -1412,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1427,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1447,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1460,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "aptos-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1485,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "aptos-github-client"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-proxy",
  "serde",
@@ -1497,17 +1496,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1519,7 +1518,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
- "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1545,11 +1544,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-system-utils 0.1.0 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "async-trait",
  "backtrace",
  "clap 4.5.19",
@@ -1567,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1597,11 +1596,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1682,12 +1681,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -1713,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1741,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1778,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1793,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1803,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1847,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1860,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1870,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1894,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1907,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1947,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1960,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -1971,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1980,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-debugger"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
@@ -2006,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2045,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2066,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2083,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2100,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2145,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-benchmark"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-config",
  "aptos-logger",
@@ -2165,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2188,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -2205,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2230,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "aptos-node"
 version = "0.0.0-main"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-admin-service",
@@ -2302,7 +2301,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2313,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2329,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2339,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2351,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2364,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2389,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-bounded-executor",
  "aptos-build-info",
@@ -2415,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2427,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2453,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2463,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -2487,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "ipnet",
 ]
@@ -2495,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2506,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -2528,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2542,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2565,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2574,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "rayon",
  "tokio",
@@ -2583,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-config",
  "aptos-consensus-types",
@@ -2607,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2624,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2643,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2665,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2683,11 +2682,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.1 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2701,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2722,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2733,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2744,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -2777,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2804,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -2815,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -2827,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2856,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -2872,10 +2871,10 @@ dependencies = [
 [[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
- "aptos-profiler 0.1.0 (git+https://github.com/Rqnsom/aptos-core.git?branch=main)",
+ "aptos-profiler 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?branch=main)",
  "async-mutex",
  "http 0.2.12",
  "hyper 0.14.30",
@@ -2912,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2930,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2969,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3009,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3018,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3031,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -3088,17 +3087,18 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 
 [[package]]
 name = "aptos-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -3119,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3221,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3236,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3258,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -7065,9 +7065,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "iprange"
@@ -7684,7 +7684,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7716,12 +7716,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "once_cell",
  "quote",
@@ -7746,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -7772,7 +7772,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "difference",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7938,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -7955,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -7974,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -7986,7 +7986,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -8020,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "hex",
@@ -8033,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "codespan",
@@ -8107,7 +8107,6 @@ dependencies = [
  "codespan-reporting",
  "diffy",
  "either",
- "fixed",
  "itertools 0.13.0",
  "log",
  "move-command-line-common",
@@ -8131,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -8165,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "atty",
@@ -8192,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8221,7 +8220,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -8238,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "hex",
@@ -8269,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -8289,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "hex",
@@ -8312,7 +8311,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "once_cell",
  "serde",
@@ -8321,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "better_any",
  "bytes",
@@ -8336,7 +8335,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "better_any",
@@ -8365,7 +8364,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "better_any",
  "bytes",
@@ -8388,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8404,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/Rqnsom/aptos-core.git?branch=main#6d70a926e31cb6d9d2fe748ca62a93e94fc0e549"
+source = "git+https://github.com/aptos-labs/aptos-core.git?branch=main#41e82f7ee340928dc41bfc6699875ce9f08f47e2"
 dependencies = [
  "bcs 0.1.4",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ move-prover = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "
 move-symbol-pool = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 move-unit-test = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 move-vm-runtime = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
-num = "0.4"
 mutator-common = { path = "mutator-common" }
+num = "0.4"
 num-traits = "0.2"
 pretty_env_logger = "0.5"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,33 +21,31 @@ rust-version = "1.78.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
-# temporary use my fork since we need this commit:
-# https://github.com/Rqnsom/aptos-core/commit/2dbeacf7fe0d8e37aa98effd32cda8d40daf0502
-aptos = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-aptos-framework = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-aptos-gas-schedule = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-aptos-types = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-aptos-vm = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+aptos = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+aptos-framework = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+aptos-gas-schedule = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+aptos-types = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+aptos-vm = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 clap = { version = "4.5", features = ["derive"] }
 codespan = "0.11"
 codespan-reporting = "0.11"
 diffy = "0.3"
 either = "1.9"
-fixed = "= 1.25.1" # required by aptos deps
+#fixed = "= 1.25.1" # required by aptos deps
 itertools = "0.13"
 log = "0.4"
-move-cli = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-command-line-common = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-compiler = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-compiler-v2 = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-coverage = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-model = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-cli = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-command-line-common = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-compiler = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-compiler-v2 = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-coverage = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-model = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 move-mutator = { path = "move-mutator" }
-move-package = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-prover = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-symbol-pool = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-unit-test = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
-move-vm-runtime = { git = "https://github.com/Rqnsom/aptos-core.git", branch = "main" }
+move-package = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-prover = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-symbol-pool = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-unit-test = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
+move-vm-runtime = { git = "https://github.com/aptos-labs/aptos-core.git", branch = "main" }
 num = "0.4"
 mutator-common = { path = "mutator-common" }
 num-traits = "0.2"

--- a/move-mutator/Cargo.toml
+++ b/move-mutator/Cargo.toml
@@ -21,7 +21,6 @@ codespan = { workspace = true }
 codespan-reporting = { workspace = true }
 diffy = { workspace = true }
 either = { workspace = true }
-fixed = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 move-command-line-common = { workspace = true }


### PR DESCRIPTION
A fork has been used for a temporary period until the change got merged
in aptos-core repo.