### PR TITLE
feat: impl display-report command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,7 +4506,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
@@ -5560,6 +5560,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -8458,9 +8464,12 @@ name = "mutator-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "diffy",
+ "prettytable-rs",
  "serde",
  "serde_json",
  "tabled",
+ "tempfile",
 ]
 
 [[package]]
@@ -9628,6 +9637,20 @@ checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
  "env_logger 0.10.2",
  "log",
+]
+
+[[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
 ]
 
 [[package]]
@@ -11757,6 +11780,17 @@ dependencies = [
  "serde_json",
  "slug",
  "unic-segment",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ mutator-common = { path = "mutator-common" }
 num = "0.4"
 num-traits = "0.2"
 pretty_env_logger = "0.5"
+prettytable-rs = "0.10"
 rand = "0.8"
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/move-mutation-test/src/main.rs
+++ b/move-mutation-test/src/main.rs
@@ -9,6 +9,7 @@ use move_mutation_test::{
     cli::{CLIOptions, TestBuildConfig},
     run_mutation_test,
 };
+use mutator_common::display_report::{display_report_on_screen, ModuleFilter};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -36,6 +37,10 @@ enum Commands {
         /// Report location. The default file is "report.txt" under the same directory.
         #[clap(short = 'p', long, default_value = "report.txt")]
         path_to_report: PathBuf,
+
+        /// Include specified modules in the report.
+        #[clap(short = 'm', long, value_parser, default_value = "all")]
+        modules: ModuleFilter,
     },
 }
 
@@ -47,8 +52,9 @@ fn main() -> anyhow::Result<()> {
             cli_options,
             test_build_config,
         } => run_mutation_test(cli_options, test_build_config),
-        Commands::DisplayReport { path_to_report: _ } => {
-            unimplemented!("to be in the next PR soon")
-        },
+        Commands::DisplayReport {
+            path_to_report,
+            modules,
+        } => display_report_on_screen(path_to_report.as_path(), modules),
     }
 }

--- a/move-spec-test/src/lib.rs
+++ b/move-spec-test/src/lib.rs
@@ -103,7 +103,7 @@ pub fn run_spec_test(
     // Proving part.
     move_mutator::compiler::copy_dir_all(&package_path, &outdir_original)?;
 
-    let mut spec_report = Report::new();
+    let mut spec_report = Report::new(package_path.to_owned());
 
     let mut proving_benchmarks = vec![Benchmark::new(); report.get_mutants().len()];
     benchmarks.prover.start();

--- a/mutator-common/Cargo.toml
+++ b/mutator-common/Cargo.toml
@@ -12,6 +12,11 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-tabled = { workspace = true }
+diffy = { workspace = true }
+prettytable-rs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tabled = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/mutator-common/src/display_report.rs
+++ b/mutator-common/src/display_report.rs
@@ -1,0 +1,250 @@
+//! A module for displaying reports in a nice fashion.
+// Copyright © Eiger
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::report::Report;
+use crate::report::MutantStats;
+use anyhow::{Context, Result};
+use diffy::Line;
+use prettytable::{color, format, Attr, Cell, Row, Table};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+/// Filter for modules to include in the report.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub enum ModuleFilter {
+    #[default]
+    All,
+    Selected(Vec<String>),
+}
+
+impl FromStr for ModuleFilter {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(ModuleFilter::All),
+            _ => Ok(ModuleFilter::Selected(
+                s.split(&[';', '-', ',']).map(String::from).collect(),
+            )),
+        }
+    }
+}
+
+impl ModuleFilter {
+    fn get_all_files_containing_the_modules(&self, report: &Report) -> HashSet<PathBuf> {
+        match *self {
+            Self::All => report.entries().keys().cloned().collect(),
+            Self::Selected(ref modules) => {
+                let mut files_to_print = HashSet::<PathBuf>::new();
+
+                for module in modules {
+                    for (file, mutants) in report.entries() {
+                        if mutants.iter().any(|m| &m.get_module_name() == module) {
+                            files_to_print.insert(file.clone());
+                            break;
+                        }
+                    }
+                }
+                files_to_print
+            },
+        }
+    }
+}
+
+/// Line stats for mutations.
+#[derive(Default, Debug)]
+struct MutatedLine {
+    /// Number of total mutants.
+    total_mutants: u32,
+
+    /// Number of killed mutants.
+    killed_mutants: u32,
+}
+
+impl From<&MutantStats> for MutatedLine {
+    fn from(mutant_stats: &MutantStats) -> Self {
+        Self {
+            killed_mutants: mutant_stats.killed,
+            total_mutants: mutant_stats.tested,
+        }
+    }
+}
+
+/// Line number. The first line is indexed from 1.
+type LineNumber = usize;
+
+/// File statistics about the mutated lines.
+#[derive(Default, Debug)]
+struct FileStats {
+    /// Info about mutated lines.
+    mutated_lines: BTreeMap<LineNumber, MutatedLine>,
+}
+
+impl FileStats {
+    fn increment_killed_per_line(&mut self, line_number: LineNumber) {
+        let mutated_line = self.mutated_lines.entry(line_number).or_default();
+        mutated_line.total_mutants += 1;
+        mutated_line.killed_mutants += 1;
+    }
+
+    fn increment_total_per_line(&mut self, line_number: LineNumber) {
+        let mutated_line = self.mutated_lines.entry(line_number).or_default();
+        mutated_line.total_mutants += 1;
+    }
+}
+
+/// Displays a friendly readable report for given modules.
+pub fn display_report_on_screen(path_to_report: &Path, modules: &ModuleFilter) -> Result<()> {
+    let report = Report::load_from_json_file(path_to_report)?;
+    let files_to_print = modules.get_all_files_containing_the_modules(&report);
+
+    for file in files_to_print {
+        let file_stats = calculate_file_stats(&file, &report)?;
+
+        // Get the absolute file path.
+        let abs_file_path = report.get_package_dir().to_path_buf().join(&file);
+        let source_code = std::fs::read_to_string(&abs_file_path)?;
+
+        print_nice_report(&file, source_code, file_stats)?;
+    }
+
+    Ok(())
+}
+
+fn print_nice_report(file: &Path, source_code: String, stats: FileStats) -> Result<()> {
+    let mut table = Table::new();
+    let format = format::FormatBuilder::new()
+        .column_separator('|')
+        .separators(
+            &[format::LinePosition::Top, format::LinePosition::Bottom],
+            format::LineSeparator::new('-', '+', '+', '+'),
+        )
+        .padding(1, 1)
+        .build();
+    table.set_format(format);
+    table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+    table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+
+    let title = Cell::new_align(
+        file.to_str().expect("invalid path"),
+        format::Alignment::CENTER,
+    )
+    .with_hspan(2)
+    .with_style(Attr::Bold);
+    table.set_titles(Row::new(vec![title]));
+
+    // Line numbers are indexed from 1, not from 0.
+    for (line_no, line) in (1..).zip(source_code.lines()) {
+        let (mut stat_cell, line_color) = if let Some(m) = stats.mutated_lines.get(&line_no) {
+            let style_color = Attr::ForegroundColor(match m.killed_mutants {
+                0 => color::GREEN,
+                n if n == m.total_mutants => color::RED,
+                _ => color::BRIGHT_YELLOW,
+            });
+
+            (
+                Cell::new_align(
+                    &format!("{}/{}", m.killed_mutants, m.total_mutants),
+                    format::Alignment::RIGHT,
+                ),
+                Some(style_color),
+            )
+        } else {
+            (Cell::new(""), None)
+        };
+
+        let mut line_cell = Cell::new(line);
+        if let Some(color) = line_color {
+            line_cell.style(color);
+            stat_cell.style(color);
+        }
+
+        table.add_row(Row::new(vec![stat_cell, line_cell]));
+    }
+
+    table.printstd();
+    Ok(())
+}
+
+fn calculate_file_stats(file: &Path, report: &Report) -> Result<FileStats> {
+    let mut file_stats = FileStats::default();
+
+    let Some(mutants) = report.entries().get(&file.to_path_buf()) else {
+        return Ok(file_stats);
+    };
+
+    for mutant in mutants {
+        for patch_str in &mutant.mutants_alive_diffs {
+            let mutated_line_no = find_mutated_line_number(patch_str)?;
+            file_stats.increment_total_per_line(mutated_line_no);
+        }
+        for patch_str in &mutant.mutants_killed_diff {
+            let mutated_line_no = find_mutated_line_number(patch_str)?;
+            file_stats.increment_killed_per_line(mutated_line_no);
+        }
+    }
+
+    Ok(file_stats)
+}
+
+fn find_mutated_line_number(file_diff: &str) -> Result<usize> {
+    let patch = diffy::Patch::from_str(file_diff)?;
+    let hunk = patch
+        .hunks()
+        .first()
+        .context("invalid diff in the report")?;
+
+    let mut current_line_no = hunk.old_range().start();
+    let mut lines = hunk.lines().iter();
+
+    // Loop until Line::Deleted or Line::Insert.
+    while let Some(Line::Context(_)) = lines.next() {
+        current_line_no += 1;
+    }
+
+    Ok(current_line_no)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf};
+
+    #[test]
+    fn reading_report_from_file_works() {
+        let package_dir = tempfile::tempdir().unwrap().into_path();
+
+        let mut report = Report::new(package_dir.clone());
+        let path1 = package_dir.join("src_file1");
+        let path2 = package_dir.join("src_file2");
+        let module_name = "module";
+        report.increment_mutants_tested(&path1, module_name);
+        report.increment_mutants_tested(&path2, module_name);
+
+        let report_path = package_dir.join("report.txt");
+        report
+            .save_to_json_file(&report_path)
+            .expect("failed to save the file to a disk");
+
+        // Files also need to exist.
+        fs::File::create(path1).unwrap();
+        fs::File::create(path2).unwrap();
+
+        let modules = ModuleFilter::All;
+        let ret = display_report_on_screen(&report_path, &modules);
+        assert!(ret.is_ok());
+    }
+
+    #[test]
+    fn report_file_not_found() {
+        let path = PathBuf::from("/path/to/non/existing/file");
+        let modules = ModuleFilter::All;
+        let ret = display_report_on_screen(&path, &modules);
+        assert!(ret.is_err());
+    }
+}

--- a/mutator-common/src/lib.rs
+++ b/mutator-common/src/lib.rs
@@ -4,3 +4,6 @@
 
 /// A module for generating concise, valuable reports.
 pub mod report;
+
+/// A module for displaying reports in a nice fashion.
+pub mod display_report;

--- a/mutator-common/src/report.rs
+++ b/mutator-common/src/report.rs
@@ -3,23 +3,21 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
+    fs,
     path::{Path, PathBuf},
 };
 use tabled::{builder::Builder, settings::Style};
-
-/// A file difference that identifies mutants.
-pub type FileDiff = String;
 
 /// The final status of the mutant after running the tests on it.
 #[derive(Debug)]
 pub enum MutantStatus {
     /// Killed mutant.
     Killed,
-    /// Alive mutant containing the file difference.
-    Alive(FileDiff),
+    /// Alive mutant.
+    Alive,
 }
 
 /// This struct represents a report single mutation test.
@@ -31,15 +29,23 @@ pub struct MiniReport {
     pub qname: String,
     /// Mutant status after testing it.
     pub mutant_status: MutantStatus,
+    /// A file difference that identifies mutants.
+    pub diff: String,
 }
 
 impl MiniReport {
     /// Create a new [`MiniReport`].
-    pub fn new(original_file: PathBuf, qname: String, mutant_status: MutantStatus) -> Self {
+    pub fn new(
+        original_file: PathBuf,
+        qname: String,
+        mutant_status: MutantStatus,
+        diff: String,
+    ) -> Self {
         Self {
             original_file,
             qname,
             mutant_status,
+            diff,
         }
     }
 }
@@ -48,17 +54,20 @@ impl MiniReport {
 ///
 /// It contains the list of entries, where each entry is a file and the number of mutants tested
 /// and killed in that file (in form of a `ReportEntry` structure).
-#[derive(Debug, Serialize, Default)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Report {
     /// The list of entries in the report.
     files: BTreeMap<PathBuf, Vec<MutantStats>>,
+    /// Package directory location.
+    package_dir: PathBuf,
 }
 
 impl Report {
     /// Creates a new report.
-    pub fn new() -> Self {
+    pub fn new(package_dir: PathBuf) -> Self {
         Self {
             files: BTreeMap::new(),
+            package_dir,
         }
     }
 
@@ -85,7 +94,7 @@ impl Report {
         self.total_count(|v| v.killed)
     }
 
-    /// Add a diff for a not killed mutant.
+    /// Add a diff for a survived mutant.
     pub fn add_mutants_alive_diff(&mut self, path: &Path, module_func: &str, diff: &str) {
         let entry = self
             .files
@@ -101,11 +110,40 @@ impl Report {
         }
     }
 
+    /// Add a diff for a killed mutant.
+    pub fn add_mutants_killed_diff(&mut self, path: &Path, module_func: &str, diff: &str) {
+        let entry = self
+            .files
+            .entry(path.to_path_buf())
+            .or_insert(vec![MutantStats::new(module_func)]);
+
+        if let Some(stat) = entry.iter_mut().find(|s| s.module_func == module_func) {
+            stat.mutants_killed_diff.push(diff.to_owned());
+        } else {
+            let mut new_entry = MutantStats::new(module_func);
+            new_entry.mutants_killed_diff.push(diff.to_owned());
+            entry.push(new_entry);
+        }
+    }
+
     /// Save the report to a JSON file.
+    ///
     /// The file is created if it does not exist, otherwise it is overwritten.
-    pub fn save_to_json_file(&self, path: &PathBuf) -> anyhow::Result<()> {
-        let file = std::fs::File::create(path)?;
+    pub fn save_to_json_file(&self, path: &Path) -> anyhow::Result<()> {
+        let file = fs::File::create(path)?;
         Ok(serde_json::to_writer_pretty(file, self)?)
+    }
+
+    /// Load the report from a JSON file.
+    pub fn load_from_json_file(path: &Path) -> anyhow::Result<Self> {
+        let report = fs::read_to_string(path)?;
+        serde_json::from_str::<Report>(&report)
+            .map_err(|e| anyhow::Error::msg(format!("failed to parse the report: {e}")))
+    }
+
+    /// Get package directory.
+    pub fn get_package_dir(&self) -> &Path {
+        &self.package_dir
     }
 
     /// Prints the report to stdout in a table format.
@@ -165,7 +203,6 @@ impl Report {
     }
 
     /// Returns the list of entries in the report.
-    #[cfg(test)]
     pub fn entries(&self) -> &BTreeMap<PathBuf, Vec<MutantStats>> {
         &self.files
     }
@@ -173,7 +210,7 @@ impl Report {
 
 /// This struct represents an entry in the report.
 /// It contains the number of mutants tested and killed.
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct MutantStats {
     /// Module::function where mutant resides.
     pub module_func: String,
@@ -181,8 +218,10 @@ pub struct MutantStats {
     pub tested: u32,
     /// The number of mutants killed.
     pub killed: u32,
-    /// The list of not killed mutants.
+    /// The list of survived mutants.
     pub mutants_alive_diffs: Vec<String>,
+    /// The list of killed mutants.
+    pub mutants_killed_diff: Vec<String>,
 }
 
 impl MutantStats {
@@ -190,10 +229,18 @@ impl MutantStats {
     pub fn new(module_func: &str) -> Self {
         Self {
             module_func: module_func.to_string(),
-            tested: 0,
-            killed: 0,
-            mutants_alive_diffs: vec![],
+            ..Default::default()
         }
+    }
+
+    /// Get the name of the module where the mutation resides.
+    pub fn get_module_name(&self) -> String {
+        // Unfallable.
+        self.module_func
+            .split("::")
+            .next()
+            .expect("module name not found")
+            .to_owned()
     }
 }
 
@@ -204,13 +251,13 @@ mod tests {
 
     #[test]
     fn report_starts_empty() {
-        let report = Report::new();
+        let report = Report::new("package_dir".into());
         assert_eq!(report.entries().len(), 0);
     }
 
     #[test]
     fn increment_mutants_tested_adds_new_module_if_not_present() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path = PathBuf::from("path/to/file");
         let module_name = "new_module";
         report.increment_mutants_tested(&path, module_name);
@@ -220,7 +267,7 @@ mod tests {
 
     #[test]
     fn increment_mutants_killed_adds_new_module_if_not_present() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path = PathBuf::from("path/to/file");
         let module_name = "new_module";
         report.increment_mutants_killed(&path, module_name);
@@ -230,7 +277,7 @@ mod tests {
 
     #[test]
     fn increment_mutants_tested_increases_tested_count_for_existing_module() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path = PathBuf::from("path/to/file");
         let module_name = "existing_module";
         report.increment_mutants_tested(&path, module_name);
@@ -243,7 +290,7 @@ mod tests {
 
     #[test]
     fn increment_mutants_killed_increases_killed_count_for_existing_module() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path = PathBuf::from("path/to/file");
         let module_name = "existing_module";
         report.increment_mutants_killed(&path, module_name);
@@ -256,7 +303,7 @@ mod tests {
 
     #[test]
     fn mutants_tested_returns_correct_total_tested_count() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path1 = PathBuf::from("path/to/file1");
         let path2 = PathBuf::from("path/to/file2");
         let module_name = "module";
@@ -268,7 +315,7 @@ mod tests {
 
     #[test]
     fn mutants_killed_returns_correct_total_killed_count() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path1 = PathBuf::from("path/to/file1");
         let path2 = PathBuf::from("path/to/file2");
         let module_name = "module";
@@ -280,7 +327,7 @@ mod tests {
 
     #[test]
     fn add_mutants_alive_diff_adds_new_module_if_not_present() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path = PathBuf::from("path/to/file");
         let module_name = "new_module";
         let diff = "diff";
@@ -294,7 +341,7 @@ mod tests {
 
     #[test]
     fn add_mutants_alive_diff_adds_diff_to_existing_module() {
-        let mut report = Report::new();
+        let mut report = Report::new("package_dir".into());
         let path = PathBuf::from("path/to/file");
         let module_name = "existing_module";
         let diff1 = "diff1";


### PR DESCRIPTION
A new coloured output for the report.txt has been implemented here.

An example:
```text
                 sources/Sum.move
---------+-----------------------------------------
         | module TestAccount::Sum {
         |     fun sub(x: u64, y: u64): u64 {
     0/4 |         x - y
         |     }
         |
         |     fun sum(x: u128, y: u128): u128 {
     4/4 |         let sum_r = x + y;
         |         spec {
         |                 assert sum_r == x+y;
         |         };
         |
         |         sum_r
         |     }

```