### PR TITLE
feat(move-mutator): add rayon for concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ build/
 # move-mutator and move-spec-test output files
 report.json
 mutants_output
+report.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8129,6 +8129,7 @@ dependencies = [
  "num-traits",
  "pretty_env_logger",
  "rand 0.8.5",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",

--- a/move-mutator/Cargo.toml
+++ b/move-mutator/Cargo.toml
@@ -35,6 +35,7 @@ num = { workspace = true }
 num-traits = { workspace = true }
 pretty_env_logger = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/move-spec-test/src/cli.rs
+++ b/move-spec-test/src/cli.rs
@@ -18,7 +18,7 @@ pub struct CLIOptions {
     pub move_sources: Vec<PathBuf>,
 
     /// Work only over specified modules.
-    #[clap(long, short, value_parser, default_value = "all")]
+    #[clap(long, value_parser, default_value = "all")]
     pub mutate_modules: ModuleFilter,
 
     /// Work only over specified functions (these are not qualifed functions).


### PR DESCRIPTION
The speed boost is evident below (when mutator tool is combined with mutation-test tool:

New solution:
```sh
$ RUST_LOG=info move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt --mutate-modules=Operators
INFO  move_mutation_test::benchmark > In total, mutation testing took 30914 msecs
 INFO  move_mutation_test::benchmark > Generating mutants took 16603 msecs
 INFO  move_mutation_test::benchmark > Mutation testing took 12516 msecs
 INFO  move_mutation_test::benchmark > Min mutation testing time for a mutant: 905 msecs
 INFO  move_mutation_test::benchmark > Max mutation testing time for a mutant: 12135 msecs
 INFO  move_mutation_test::benchmark > Average mutation testing time for each mutant: 6722 msecs
```

vs old solution:
```sh
$ RUST_LOG=info move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt --mutate-modules=Operators
[15:04](https://eig3r.slack.com/archives/D0413FZC39S/p1729083884898399)
INFO  move_mutation_test::benchmark > In total, mutation testing took 24767 msecs
 INFO  move_mutation_test::benchmark > Generating mutants took 10619 msecs
 INFO  move_mutation_test::benchmark > Mutation testing took 12403 msecs
 INFO  move_mutation_test::benchmark > Min mutation testing time for a mutant: 971 msecs
 INFO  move_mutation_test::benchmark > Max mutation testing time for a mutant: 12118 msecs
 INFO  move_mutation_test::benchmark > Average mutation testing time for each mutant: 6578 msecs
[15:04](https://eig3r.slack.com/archives/D0413FZC39S/p1729083892966829)
RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt --mutate-modules=Operators
```