### PR TITLE
refactor: optimize dir copy processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8094,6 +8094,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "clap 4.5.20",
+ "fs_extra",
  "log",
  "move-cli",
  "move-command-line-common",
@@ -8107,7 +8108,6 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "serde",
- "tempfile",
  "termcolor",
 ]
 
@@ -8270,6 +8270,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
+ "fs_extra",
  "log",
  "move-model",
  "move-mutator",
@@ -8279,7 +8280,6 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "serde",
- "tempfile",
  "termcolor",
 ]
 
@@ -8478,6 +8478,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "diffy",
+ "fs_extra",
+ "log",
+ "move-mutator",
+ "move-package",
  "prettytable-rs",
  "serde",
  "serde_json",

--- a/move-mutation-test/Cargo.toml
+++ b/move-mutation-test/Cargo.toml
@@ -22,6 +22,7 @@ aptos-gas-schedule = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 clap = { workspace = true }
+fs_extra = { workspace = true }
 log = { workspace = true }
 move-cli = { workspace = true }
 move-command-line-common = { workspace = true }
@@ -35,5 +36,4 @@ mutator-common = { workspace = true }
 pretty_env_logger = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
-tempfile = { workspace = true }
 termcolor = { workspace = true }

--- a/move-mutation-test/src/lib.rs
+++ b/move-mutation-test/src/lib.rs
@@ -15,8 +15,12 @@ use crate::{
     mutation_test::{run_tests_on_mutated_code, run_tests_on_original_code},
 };
 use cli::TestBuildConfig;
-use move_package::{source_package::layout::SourcePackageLayout, BuildConfig};
-use mutator_common::report::{MiniReport, MutantStatus, Report};
+use fs_extra::dir::CopyOptions;
+use move_package::BuildConfig;
+use mutator_common::{
+    report::{MiniReport, MutantStatus, Report},
+    tmp_package_dir::{setup_outdir_and_package_path, strip_path_prefix},
+};
 use rayon::prelude::*;
 use std::{
     fs,
@@ -50,12 +54,10 @@ pub fn run_mutation_test(
     // (e.g. move-mutator). If we use init() instead, we will get an abort.
     let _ = pretty_env_logger::try_init();
 
-    // Check if the package is correctly structured.
-    let package_path = SourcePackageLayout::try_find_root(
-        &test_config.move_pkg.get_package_path()?.canonicalize()?,
-    )?;
+    // Setup output dir and clone package path there.
+    let original_package_path = test_config.move_pkg.get_package_path()?;
+    let (outdir, package_path) = setup_outdir_and_package_path(original_package_path)?;
 
-    info!("Found package path: {package_path:?}");
     info!("Running tool the following options: {options:?} and test config: {test_config:?}");
 
     // Always create and use benchmarks.
@@ -68,12 +70,6 @@ pub fn run_mutation_test(
     run_tests_on_original_code(test_config, &package_path)?;
 
     // Create mutants:
-
-    // Setup temporary directory structure.
-    let outdir = tempfile::tempdir()?.into_path();
-    let outdir_original = outdir.join("base");
-    fs::create_dir_all(outdir_original)?;
-
     let outdir_mutant = if let Some(mutant_path) = &options.use_generated_mutants {
         mutant_path.clone()
     } else {
@@ -102,6 +98,7 @@ pub fn run_mutation_test(
 
     // Run tests on mutants:
     benchmarks.mutation_test.start();
+    let cp_opts = CopyOptions::new().content_only(true);
     let (mutation_test_benchmarks, mini_reports): (Vec<Benchmark>, Vec<MiniReport>) = report
         .get_mutants()
         .par_iter()
@@ -116,35 +113,26 @@ pub fn run_mutation_test(
                 mutant_file.display()
             );
 
-            // Strip prefix to get the path relative to the package directory (or take that path if it's already relative).
-            let original_file = elem
-                .original_file_path()
-                .strip_prefix(&package_path)
-                .unwrap_or(elem.original_file_path());
-            let job_work_dir = format!("mutation_test_{rayon_thread_id}");
-            let outdir = outdir.join(job_work_dir);
+            // Strip prefix to get the path relative to the package directory.
+            let original_file =
+                strip_path_prefix(elem.original_file_path()).expect("invalid package path");
 
-            let _ = fs::remove_dir_all(&outdir);
-            move_mutator::compiler::copy_dir_all(&package_path, &outdir)
+            let job_outdir = outdir.join(format!("mutation_test_{rayon_thread_id}"));
+            let _ = fs::remove_dir_all(&job_outdir);
+
+            fs_extra::dir::copy(&package_path, &job_outdir, &cp_opts)
                 .expect("copying directory failed");
 
             trace!(
                 "Copying mutant file {} to the package directory {:?}",
                 mutant_file.display(),
-                outdir.join(original_file)
+                job_outdir.join(&original_file)
             );
-
             // Should never fail, since files will always exists.
-            let _ = fs::copy(mutant_file, outdir.join(original_file));
-
-            if let Err(e) =
-                move_mutator::compiler::rewrite_manifest_for_mutant(&package_path, &outdir)
-            {
-                panic!("rewriting manifest for mutant failed: {e}");
-            }
+            fs::copy(mutant_file, job_outdir.join(&original_file)).expect("copying file failed");
 
             benchmark.start();
-            let result = run_tests_on_mutated_code(test_config, &outdir);
+            let result = run_tests_on_mutated_code(test_config, &job_outdir);
             benchmark.stop();
 
             let mutant_status = if let Err(e) = result {

--- a/move-spec-test/Cargo.toml
+++ b/move-spec-test/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+fs_extra = { workspace = true }
 log = { workspace = true }
 move-model = { workspace = true }
 move-mutator = { workspace = true }
@@ -26,5 +27,4 @@ mutator-common = { workspace = true }
 pretty_env_logger = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
-tempfile = { workspace = true }
 termcolor = { workspace = true }

--- a/move-spec-test/src/lib.rs
+++ b/move-spec-test/src/lib.rs
@@ -17,8 +17,12 @@ use crate::{
     prover::prove,
 };
 use anyhow::anyhow;
-use move_package::{source_package::layout::SourcePackageLayout, BuildConfig};
-use mutator_common::report::{MiniReport, MutantStatus, Report};
+use fs_extra::dir::CopyOptions;
+use move_package::BuildConfig;
+use mutator_common::{
+    report::{MiniReport, MutantStatus, Report},
+    tmp_package_dir::{setup_outdir_and_package_path, strip_path_prefix},
+};
 use rayon::prelude::*;
 use std::{
     fs,
@@ -48,16 +52,15 @@ use std::{
 pub fn run_spec_test(
     options: &cli::CLIOptions,
     config: &BuildConfig,
-    package_path: &Path,
+    original_package_path: &Path,
 ) -> anyhow::Result<()> {
     // We need to initialize logger using try_init() as it might be already initialized in some other tool
     // (e.g. move-mutator). If we use init() instead, we will get an abort.
     let _ = pretty_env_logger::try_init();
 
-    // Check if package is correctly structured.
-    let package_path = SourcePackageLayout::try_find_root(&package_path.canonicalize()?)?;
+    // Setup output dir and clone package path there.
+    let (outdir, package_path) = setup_outdir_and_package_path(original_package_path)?;
 
-    info!("Found package path: {package_path:?}");
     info!("Running specification tester with the following options: {options:?}");
 
     // Always create and use benchmarks.
@@ -78,12 +81,6 @@ pub fn run_spec_test(
         return Err(anyhow!(msg));
     }
 
-    // Setup temporary directory structure.
-    let outdir = tempfile::tempdir()?.into_path();
-    let outdir_original = outdir.join("base");
-
-    fs::create_dir_all(&outdir_original)?;
-
     // We can skip fetching the latest deps for generating mutants and proving those mutants
     // since the original prover verification already fetched the latest dependencies.
     let mut quick_config = config.clone();
@@ -93,7 +90,6 @@ pub fn run_spec_test(
         mutant_path.clone()
     } else {
         benchmarks.mutator.start();
-
         let outdir_mutant = run_mutator(options, &quick_config, &package_path, &outdir)?;
         benchmarks.mutator.stop();
         outdir_mutant
@@ -102,10 +98,8 @@ pub fn run_spec_test(
     let report =
         move_mutator::report::Report::load_from_json_file(&outdir_mutant.join("report.json"))?;
 
-    // Proving part.
-    move_mutator::compiler::copy_dir_all(&package_path, &outdir_original)?;
-
     benchmarks.prover.start();
+    let cp_opts = CopyOptions::new().content_only(true);
     let (proving_benchmarks, mini_reports): (Vec<Benchmark>, Vec<MiniReport>) = report
         .get_mutants()
         .par_iter()
@@ -120,35 +114,26 @@ pub fn run_spec_test(
                 mutant_file.display()
             );
 
-            // Strip prefix to get the path relative to the package directory (or take that path if it's already relative).
-            let original_file = elem
-                .original_file_path()
-                .strip_prefix(&package_path)
-                .unwrap_or(elem.original_file_path());
-            let job_work_dir = format!("prover_{rayon_thread_id}");
-            let outdir = outdir.join(job_work_dir);
+            // Strip prefix to get the path relative to the package directory.
+            let original_file =
+                strip_path_prefix(elem.original_file_path()).expect("invalid package path");
+            let job_outdir = outdir.join(format!("prover_{rayon_thread_id}"));
 
-            let _ = fs::remove_dir_all(&outdir);
-            move_mutator::compiler::copy_dir_all(&package_path, &outdir)
+            let _ = fs::remove_dir_all(&job_outdir);
+            fs_extra::dir::copy(&package_path, &job_outdir, &cp_opts)
                 .expect("copying directory failed");
 
             trace!(
-                "Copying mutant file {mutant_file:?} to the package directory {:?}",
-                outdir.join(original_file)
+                "Copying mutant file {} to the package directory {}",
+                mutant_file.display(),
+                outdir.join(&original_file).display()
             );
-
             // Should never fail, since files will always exists.
-            let _ = fs::copy(mutant_file, outdir.join(original_file));
-
-            if let Err(e) =
-                move_mutator::compiler::rewrite_manifest_for_mutant(&package_path, &outdir)
-            {
-                panic!("rewriting manifest for mutant failed: {e}");
-            }
+            fs::copy(mutant_file, job_outdir.join(&original_file)).expect("copying file failed");
 
             benchmark.start();
             let mut error_writer = std::io::sink();
-            let result = prove(&quick_config, &outdir, &prover_conf, &mut error_writer);
+            let result = prove(&quick_config, &job_outdir, &prover_conf, &mut error_writer);
             benchmark.stop();
 
             let mutant_status = if let Err(e) = result {

--- a/mutator-common/Cargo.toml
+++ b/mutator-common/Cargo.toml
@@ -13,10 +13,12 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 diffy = { workspace = true }
+fs_extra = { workspace = true }
+log = { workspace = true }
+move-mutator = { workspace = true }
+move-package = { workspace = true }
 prettytable-rs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tabled = { workspace = true }
-
-[dev-dependencies]
 tempfile = { workspace = true }

--- a/mutator-common/src/lib.rs
+++ b/mutator-common/src/lib.rs
@@ -7,3 +7,6 @@ pub mod report;
 
 /// A module for displaying reports in a nice fashion.
 pub mod display_report;
+
+/// A path setup container for packages under test.
+pub mod tmp_package_dir;

--- a/mutator-common/src/report.rs
+++ b/mutator-common/src/report.rs
@@ -160,7 +160,7 @@ impl Report {
                 };
 
                 builder.push_record([
-                    format!("{}::{}", path.to_string_lossy(), stat.module_func.clone()),
+                    format!("{}::{}", path.display(), stat.module_func.clone()),
                     stat.tested.to_string(),
                     stat.killed.to_string(),
                     format!("{percentage:.2}%"),

--- a/mutator-common/src/tmp_package_dir.rs
+++ b/mutator-common/src/tmp_package_dir.rs
@@ -1,0 +1,72 @@
+//! A path setup container for packages under test.
+// Copyright © Eiger
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use fs_extra::dir::CopyOptions;
+use log::{info, trace};
+use move_package::source_package::layout::SourcePackageLayout;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// The path in temp dir where the original Move package is cloned.
+const ORIGINAL_PACKAGE_PATH: &str = "original_package";
+
+/// Returns the output directory and a recreated package path.
+pub fn setup_outdir_and_package_path<P: AsRef<Path>>(
+    package_path: P,
+) -> Result<(PathBuf, PathBuf)> {
+    // Check if the package is correctly structured.
+    let package_path = SourcePackageLayout::try_find_root(&package_path.as_ref().canonicalize()?)?;
+    info!("Found package path: {package_path:?}");
+
+    let outdir = tempfile::tempdir()?.into_path();
+    let new_package_path = outdir.join(ORIGINAL_PACKAGE_PATH);
+    fs::create_dir_all(&new_package_path)?;
+
+    let options = CopyOptions::new().content_only(true);
+    fs_extra::dir::copy(&package_path, &new_package_path, &options)?;
+
+    move_mutator::compiler::rewrite_manifest_for_mutant(&package_path, &new_package_path)?;
+
+    // Since the tool will copy the original package often, remove unnecessary files.
+    let remove_item = |item_name: &str| {
+        let item_path = new_package_path.join(item_name);
+        let result = if item_path.is_dir() {
+            fs::remove_dir_all(&item_path)
+        } else {
+            fs::remove_file(&item_path)
+        };
+        if result.is_ok() {
+            trace!("removed {}", item_path.display());
+        }
+    };
+    [
+        "build",
+        "doc",
+        ".trace",
+        "output.bpl",
+        "doc_template",
+        "report.txt",
+    ]
+    .iter()
+    .for_each(|&dir| remove_item(dir));
+
+    Ok((outdir, new_package_path))
+}
+
+/// Helper method to strip the temp dir prefix and keep only the `sources/xxx.move` path.
+pub fn strip_path_prefix<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
+    let original_file = path.as_ref().to_string_lossy();
+
+    // This should always work.
+    let sources_dir_idx = original_file
+        .find(ORIGINAL_PACKAGE_PATH).ok_or(anyhow::Error::msg("original package path not found"))?
+        + ORIGINAL_PACKAGE_PATH.len() // skip package path.
+        + 1; // skip the `/` character before 'sources'.
+
+    Ok(PathBuf::from(&original_file[sources_dir_idx..]))
+}


### PR DESCRIPTION
Ensure the tools never perform any executions within the original package path. Before the tool is started, the package path is cloned to another temp location. Then, all the work is done with that copy of the original project directory.