### PR TITLE
chore: incorrect coverage report workaround

### DIFF
--- a/move-mutator/src/coverage.rs
+++ b/move-mutator/src/coverage.rs
@@ -181,11 +181,19 @@ fn merge_spans_after_removing_whitespaces(mut spans: Vec<Span>, source_code: &st
         return vec![];
     }
 
+    let file_len = source_code.len();
     let mut new_spans = Vec::with_capacity(spans.len());
     let mut curr = spans.remove(0);
 
     'span_loop: for span in spans {
         let mut curr_end_index = curr.end().to_usize();
+
+        if curr_end_index > file_len {
+            // TODO: Write an issue in aptos-core for this since this happens in aptos-stdlib.
+            warn!("coverage report contains out of bound index {curr:?} (file length: {file_len})");
+            // Ignore such a span and continue.
+            continue;
+        }
 
         let src_chars = source_code[curr_end_index..].chars();
         for next_char in src_chars {


### PR DESCRIPTION
Sometimes, a coverage report generated by the `aptos move test --coverage` command will generate a file that contains out of bound indices. We should ignore such spans.

This should be report in the `aptos-core` repo.