### PR TITLE
feat: add command to display mutants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8529,6 +8529,7 @@ name = "mutator-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 4.5.20",
  "diffy",
  "fs_extra",
  "log",

--- a/move-mutation-test/tests/integration_tests.rs
+++ b/move-mutation-test/tests/integration_tests.rs
@@ -1,11 +1,14 @@
 use aptos::common::types::MovePackageDir;
 use log::info;
-use move_mutation_test::cli::CLIOptions;
-use move_mutation_test::cli::TestBuildConfig;
-use move_mutation_test::run_mutation_test;
+use move_mutation_test::{
+    cli::{CLIOptions, TestBuildConfig},
+    run_mutation_test,
+};
 use mutator_common::report::Report;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 // Arbitrarily chosen after manual testing.
 // Tweaking only changes the overall duration of the test a little.

--- a/move-spec-test/src/main.rs
+++ b/move-spec-test/src/main.rs
@@ -8,7 +8,9 @@ use clap::{Parser, Subcommand};
 use move_mutator::cli::PackagePathCheck;
 use move_package::BuildConfig;
 use move_spec_test::{cli::CLIOptions, run_spec_test};
-use mutator_common::display_report::{display_report_on_screen, ModuleFilter};
+use mutator_common::display_report::{
+    display_coverage_on_screen, display_mutants_on_screen, DisplayReportCmd, DisplayReportOptions,
+};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -37,15 +39,7 @@ enum Commands {
     },
 
     /// Display the report in a more readable format.
-    DisplayReport {
-        /// Report location. The default file is "report.txt" under the same directory.
-        #[clap(short = 'p', long, default_value = "report.txt")]
-        path_to_report: PathBuf,
-
-        /// Include specified modules in the report.
-        #[clap(short = 'm', long, value_parser, default_value = "all")]
-        modules: ModuleFilter,
-    },
+    DisplayReport(DisplayReportOptions),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -60,9 +54,16 @@ fn main() -> anyhow::Result<()> {
             let package_path = cli_options.resolve(package_path)?;
             run_spec_test(&cli_options, &build_config, &package_path)
         },
-        Commands::DisplayReport {
-            path_to_report,
-            modules,
-        } => display_report_on_screen(path_to_report.as_path(), &modules),
+        Commands::DisplayReport(display_report) => {
+            let path_to_report = &display_report.path_to_report;
+            let modules = &display_report.modules;
+
+            match &display_report.cmds {
+                DisplayReportCmd::Coverage => display_coverage_on_screen(path_to_report, modules),
+                DisplayReportCmd::Mutants { functions, mutants } => {
+                    display_mutants_on_screen(path_to_report, modules, functions, mutants)
+                },
+            }
+        },
     }
 }

--- a/move-spec-test/tests/integration_tests.rs
+++ b/move-spec-test/tests/integration_tests.rs
@@ -1,10 +1,11 @@
 use log::info;
 use move_package::BuildConfig;
-use move_spec_test::cli::CLIOptions;
-use move_spec_test::run_spec_test;
+use move_spec_test::{cli::CLIOptions, run_spec_test};
 use mutator_common::report::Report;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 // Arbitrarily chosen after manual testing.
 // Tweaking only changes the overall duration of the test a little.

--- a/mutator-common/Cargo.toml
+++ b/mutator-common/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
 diffy = { workspace = true }
 fs_extra = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
`display-report` command has been split into two pieces:
- `coverage`
- `mutants`

Here's the new output for the command:
```
Usage: move-mutation-test display-report [OPTIONS] <COMMAND>

Commands:
  coverage  Display report in the coverage format
  mutants   Display mutants
  help      Print this message or the help of the given subcommand(s)

Options:
  -p, --path-to-report <PATH_TO_REPORT>  Report location. The default file is "report.txt" under the same directory [default: report.txt]
  -m, --modules <MODULES>                Include specified modules in the report [default: all]
  -h, --help                             Print help
  -V, --version                          Print version
```

```
Usage: move-mutation-test display-report mutants [OPTIONS]

Options:
      --functions <FUNCTIONS>            Include specified functions in the output [default: all]
  -p, --path-to-report <PATH_TO_REPORT>  Report location. The default file is "report.txt" under the same directory [default: report.txt]
  -m, --modules <MODULES>                Include specified modules in the report [default: all]
      --mutants <MUTANTS>                Specify which mutants to print [default: alive]
  -h, --help                             Print help
  -V, --version                          Print version
```

And here is an example output:
```
simple $ ../../../../target/release/move-mutation-test display-report mutants
----------------------------------------------------------------------------------------------------
BinaryReplacement::is_x_eq_to_zero: Alive mutant
--- original
+++ modified
@@ -1,6 +1,6 @@
 module TestAccount::BinaryReplacement {
     fun is_x_eq_to_zero(x: u64): bool {
-        if (x == 0)
+        if (true)
             return true;

         false

----------------------------------------------------------------------------------------------------
BinaryReplacement::is_x_eq_to_zero: Alive mutant
--- original
+++ modified
@@ -1,6 +1,6 @@
 module TestAccount::BinaryReplacement {
     fun is_x_eq_to_zero(x: u64): bool {
-        if (x == 0)
+        if (false)
             return true;

         false
```