### PR TITLE
feat: add move-2 support for compound assignments

### DIFF
--- a/move-mutation-test/tests/integration_tests.rs
+++ b/move-mutation-test/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 use aptos::common::types::MovePackageDir;
 use log::info;
+use move_model::metadata::{CompilerVersion, LanguageVersion};
 use move_mutation_test::{
     cli::{CLIOptions, TestBuildConfig},
     run_mutation_test,
@@ -22,6 +23,11 @@ fn test_run_mutation_test(path: &Path, expected_report: String) -> datatest_stab
 
     let mut move_pkg = MovePackageDir::new();
     move_pkg.package_dir = Some(PathBuf::from(package_path));
+    // Run the tests with move 2 compiler by default.
+    move_pkg.move_2 = true;
+    move_pkg.language_version = Some(LanguageVersion::V2_1);
+    move_pkg.compiler_version = Some(CompilerVersion::V2_1);
+
     let test_build_cfg = TestBuildConfig {
         move_pkg,
         dump_state: false,

--- a/move-mutator/src/compiler.rs
+++ b/move-mutator/src/compiler.rs
@@ -72,7 +72,8 @@ pub fn generate_ast(
         prepare_compiler_for_files(config, source_files.as_slice())
     };
 
-    let env = run_checker(options.clone())?;
+    trace!("{options:?}");
+    let env = run_checker(options)?;
 
     if env.has_errors() {
         let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
@@ -208,6 +209,9 @@ fn prepare_compiler_for_package(
             .collect(),
         skip_attribute_checks: config.compiler_config.skip_attribute_checks,
         known_attributes: known_attributes.clone(),
+        language_version: config.compiler_config.language_version,
+        compiler_version: config.compiler_config.compiler_version,
+        experiments: config.compiler_config.experiments.clone(),
         ..Default::default()
     };
 

--- a/move-mutator/tests/move-assets/simple/report.txt.mutation-exp
+++ b/move-mutator/tests/move-assets/simple/report.txt.mutation-exp
@@ -99,15 +99,12 @@
       },
       {
         "module_func": "BinaryReplacement::is_zero_silly_code",
-        "tested": 20,
-        "killed": 14,
+        "tested": 11,
+        "killed": 8,
         "mutants_alive_diffs": [
           "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (false)\n             return true;\n\n         // Another check which does the same is silly:\n",
           "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (0 > x)\n             return true;\n\n         // Another check which does the same is silly:\n",
-          "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (18446744073709551615 == x)\n             return true;\n\n         // Another check which does the same is silly:\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (false)\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (x < 0)\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (x == 18446744073709551615)\n             return true;\n\n         false\n"
+          "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (18446744073709551615 == x)\n             return true;\n\n         // Another check which does the same is silly:\n"
         ],
         "mutants_killed_diff": [
           "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (true)\n             return true;\n\n         // Another check which does the same is silly:\n",
@@ -117,12 +114,6 @@
           "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (0 <= x)\n             return true;\n\n         // Another check which does the same is silly:\n",
           "--- original\n+++ modified\n@@ -28,7 +28,7 @@\n     // and that would be a clear indication of silly code that has\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n-        if (0 == x)\n+        if (1 == x)\n             return true;\n\n         // Another check which does the same is silly:\n",
           "--- original\n+++ modified\n@@ -29,7 +29,7 @@\n     // one identical reduntant check.\n     fun is_zero_silly_code(x: u64): bool {\n         if (0 == x)\n-            return true;\n+            return false;\n\n         // Another check which does the same is silly:\n         if (x == 0)\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (true)\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (!(x == 0))\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (x != 0)\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (x > 0)\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (x >= 0)\n             return true;\n\n         false\n",
-          "--- original\n+++ modified\n@@ -32,7 +32,7 @@\n             return true;\n\n         // Another check which does the same is silly:\n-        if (x == 0)\n+        if (x == 1)\n             return true;\n\n         false\n",
           "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n         if (x == 0)\n             return true;\n\n-        false\n+        true\n     }\n\n     #[test]\n"
         ]
       }

--- a/move-mutator/tests/move-assets/simple_move_2_features/Move.toml
+++ b/move-mutator/tests/move-assets/simple_move_2_features/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "simple_move_2_features"
+version = "0.0.0"
+
+[dependencies.AptosStdlib]
+git = 'https://github.com/aptos-labs/aptos-core.git'
+rev = 'main'
+subdir = 'aptos-move/framework/aptos-stdlib'
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/move-mutator/tests/move-assets/simple_move_2_features/report.txt.mutation-exp
+++ b/move-mutator/tests/move-assets/simple_move_2_features/report.txt.mutation-exp
@@ -1,0 +1,115 @@
+{
+  "files": {
+    "sources/Operators.move": [
+      {
+        "module_func": "Operators::and",
+        "tested": 2,
+        "killed": 2,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -119,7 +119,7 @@\n\n     fun and(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret &= y;\n+        ret |= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -119,7 +119,7 @@\n\n     fun and(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret &= y;\n+        ret ^= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::div",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::lsh",
+        "tested": 1,
+        "killed": 1,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -180,7 +180,7 @@\n\n     fun lsh(x: u64, y: u8): u64 {\n         let ret = x;\n-        ret <<= y;\n+        ret >>= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::mod",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret /= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::mul",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret /= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::or",
+        "tested": 2,
+        "killed": 2,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -141,7 +141,7 @@\n\n     fun or(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret |= y;\n+        ret &= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -141,7 +141,7 @@\n\n     fun or(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret |= y;\n+        ret ^= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::rsh",
+        "tested": 1,
+        "killed": 1,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -204,7 +204,7 @@\n\n     fun rsh(x: u64, y: u8): u64 {\n         let ret = x;\n-        ret >>= y;\n+        ret <<= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::sub",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret /= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::sum",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret /= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::xor",
+        "tested": 2,
+        "killed": 2,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -164,7 +164,7 @@\n\n     fun xor(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret ^= y;\n+        ret |= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -164,7 +164,7 @@\n\n     fun xor(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret ^= y;\n+        ret &= y;\n         ret\n     }\n\n"
+        ]
+      }
+    ]
+  },
+  "package_dir": "move-spec-testing/move-mutator/tests/move-assets/simple-move-2-features"
+}

--- a/move-mutator/tests/move-assets/simple_move_2_features/report.txt.spec-exp
+++ b/move-mutator/tests/move-assets/simple_move_2_features/report.txt.spec-exp
@@ -1,0 +1,115 @@
+{
+  "files": {
+    "sources/Operators.move": [
+      {
+        "module_func": "Operators::and",
+        "tested": 2,
+        "killed": 2,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -119,7 +119,7 @@\n\n     fun and(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret &= y;\n+        ret |= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -119,7 +119,7 @@\n\n     fun and(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret &= y;\n+        ret ^= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::div",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -92,7 +92,7 @@\n\n     fun div(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret /= y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::lsh",
+        "tested": 1,
+        "killed": 1,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -180,7 +180,7 @@\n\n     fun lsh(x: u64, y: u8): u64 {\n         let ret = x;\n-        ret <<= y;\n+        ret >>= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::mod",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -61,7 +61,7 @@\n\n     fun mod(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret %= y;\n+        ret /= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::mul",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret /= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -35,7 +35,7 @@\n\n     fun mul(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret *= y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::or",
+        "tested": 2,
+        "killed": 2,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -141,7 +141,7 @@\n\n     fun or(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret |= y;\n+        ret &= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -141,7 +141,7 @@\n\n     fun or(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret |= y;\n+        ret ^= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::rsh",
+        "tested": 1,
+        "killed": 1,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -204,7 +204,7 @@\n\n     fun rsh(x: u64, y: u8): u64 {\n         let ret = x;\n-        ret >>= y;\n+        ret <<= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::sub",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret += y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret /= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -16,7 +16,7 @@\n\n     fun sub(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret -= y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::sum",
+        "tested": 4,
+        "killed": 4,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret -= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret *= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret /= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -1,7 +1,7 @@\n module TestAccount::Operators {\n     fun sum(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret += y;\n+        ret %= y;\n         ret\n     }\n\n"
+        ]
+      },
+      {
+        "module_func": "Operators::xor",
+        "tested": 2,
+        "killed": 2,
+        "mutants_alive_diffs": [],
+        "mutants_killed_diff": [
+          "--- original\n+++ modified\n@@ -164,7 +164,7 @@\n\n     fun xor(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret ^= y;\n+        ret |= y;\n         ret\n     }\n\n",
+          "--- original\n+++ modified\n@@ -164,7 +164,7 @@\n\n     fun xor(x: u64, y: u64): u64 {\n         let ret = x;\n-        ret ^= y;\n+        ret &= y;\n         ret\n     }\n\n"
+        ]
+      }
+    ]
+  },
+  "package_dir": "move-spec-testing/move-mutator/tests/move-assets/simple-move-2-features"
+}

--- a/move-mutator/tests/move-assets/simple_move_2_features/sources/Operators.move
+++ b/move-mutator/tests/move-assets/simple_move_2_features/sources/Operators.move
@@ -1,0 +1,272 @@
+module TestAccount::Operators {
+    fun sum(x: u64, y: u64): u64 {
+        let ret = x;
+        ret += y;
+        ret
+    }
+
+    #[test]
+    fun sum_valid_usage_test() {
+        assert!(sum(0, 0) == 0, 0);
+        assert!(sum(1, 0) == 1, 0);
+        assert!(sum(0, 1) == 1, 0);
+        assert!(sum(5, 5) == 10, 0);
+        assert!(sum(50, 10) == 60, 0);
+    }
+
+    fun sub(x: u64, y: u64): u64 {
+        let ret = x;
+        ret -= y;
+        ret
+    }
+
+    #[test]
+    fun sub_valid_usage_test() {
+        assert!(sub(0, 0) == 0, 0);
+        assert!(sub(1, 0) == 1, 0);
+        assert!(sub(5, 5) == 0, 0);
+        assert!(sub(50, 10) == 40, 0);
+    }
+
+    #[test, expected_failure]
+    fun sub_invalid_usage_test() {
+        assert!(sub(0, 5) == 0, 0);
+    }
+
+    fun mul(x: u64, y: u64): u64 {
+        let ret = x;
+        ret *= y;
+        ret
+    }
+
+    #[test]
+    fun mul_valid_usage_test() {
+        assert!(mul(0, 0) == 0, 0);
+        assert!(mul(1, 0) == 0, 0);
+        assert!(mul(0, 2) == 0, 0);
+        assert!(mul(1, 3) == 3, 0);
+        assert!(mul(4, 1) == 4, 0);
+        assert!(mul(4, 1) == 4, 0);
+        assert!(mul(5, 2) == 10, 0);
+        assert!(mul(2, 6) == 12, 0);
+        assert!(mul(7, 7) == 49, 0);
+    }
+
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Operators)]
+    fun mul_overflow_failure_test() {
+        let a = 1 << 64;
+        let b = 1 << 64;
+        assert!(mul(a, b) != 0, 0);
+    }
+
+    fun mod(x: u64, y: u64): u64 {
+        let ret = x;
+        ret %= y;
+        ret
+    }
+
+    #[test]
+    fun mod_valid_usage_test() {
+        assert!(mod(0, 1) == 0, 0);
+        assert!(mod(0, 2) == 0, 0);
+        assert!(mod(2, 2) == 0, 0);
+        assert!(mod(4, 4) == 0, 0);
+
+        assert!(mod(0, 3) == 0, 0);
+        assert!(mod(1, 3) == 1, 0);
+        assert!(mod(2, 3) == 2, 0);
+        assert!(mod(3, 3) == 0, 0);
+        assert!(mod(4, 3) == 1, 0);
+        assert!(mod(5, 3) == 2, 0);
+        assert!(mod(6, 3) == 0, 0);
+
+        assert!(mod(67, 65) == 2, 0);
+        assert!(mod(40, 45) == 40, 0);
+    }
+
+    // TODO: This test is important as it covers division by zero. At the moment - move-mutation test cannot detect if this test is missing
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Operators)]
+    fun mod_invalid_usage_test() {
+        assert!(mod(5, 0) != 1000, 0);
+    }
+
+    fun div(x: u64, y: u64): u64 {
+        let ret = x;
+        ret /= y;
+        ret
+    }
+
+    #[test]
+    fun div_valid_usage_test() {
+        assert!(div(0, 1) == 0, 0);
+        assert!(div(0, 2) == 0, 0);
+        assert!(div(1, 2) == 0, 0);
+        assert!(div(2, 2) == 1, 0);
+
+        assert!(div(200, 10) == 20, 0);
+        assert!(div(205, 10) == 20, 0);
+        assert!(div(210, 10) == 21, 0);
+
+        assert!(div(67, 65) == 1, 0);
+        assert!(div(40, 45) == 0, 0);
+    }
+
+    // TODO: This test is important as it covers division by zero. At the moment - move-mutation test cannot detect if this test is missing
+    #[test, expected_failure(arithmetic_error, location = TestAccount::Operators)]
+    fun div_invalid_usage_test() {
+        assert!(div(50, 0) != 1000, 0);
+    }
+
+    fun and(x: u64, y: u64): u64 {
+        let ret = x;
+        ret &= y;
+        ret
+    }
+
+    #[test]
+    fun and_valid_usage_test() {
+        assert!(and(0, 0) == 0, 0);
+        assert!(and(1, 0) == 0, 0);
+        assert!(and(0, 2) == 0, 0);
+        assert!(and(1, 1) == 1, 0);
+        assert!(and(3, 3) == 3, 0);
+        assert!(and(3, 2) == 2, 0);
+        assert!(and(3, 4) == 0, 0);
+
+        assert!(and(8, 5) == 0, 0);
+        assert!(and(8, 9) == 8, 0);
+        assert!(and(8, 63) == 8, 0);
+        assert!(and(65, 64) == 64, 0);
+    }
+
+    fun or(x: u64, y: u64): u64 {
+        let ret = x;
+        ret |= y;
+        ret
+    }
+
+    #[test]
+    fun or_valid_usage_test() {
+        assert!(or(0, 0) == 0, 0);
+        assert!(or(1, 0) == 1, 0);
+        assert!(or(0, 2) == 2, 0);
+        assert!(or(1, 1) == 1, 0);
+        assert!(or(3, 3) == 3, 0);
+        assert!(or(3, 2) == 3, 0);
+        assert!(or(3, 4) == 7, 0);
+
+        assert!(or(8, 5) == 13, 0);
+        assert!(or(8, 9) == 9, 0);
+        assert!(or(8, 63) == 63, 0);
+        assert!(or(65, 64) == 65, 0);
+        assert!(or(128, 0) == 128, 0);
+    }
+
+    fun xor(x: u64, y: u64): u64 {
+        let ret = x;
+        ret ^= y;
+        ret
+    }
+
+    #[test]
+    fun xor_valid_usage_test() {
+        assert!(xor(0, 0) == 0, 0);
+        assert!(xor(1, 1) == 0, 0);
+        assert!(xor(1, 0) == 1, 0);
+        assert!(xor(0, 2) == 2, 0);
+        assert!(xor(1, 2) == 3, 0);
+        assert!(xor(128, 0) == 128, 0);
+    }
+
+    fun lsh(x: u64, y: u8): u64 {
+        let ret = x;
+        ret <<= y;
+        ret
+    }
+
+    #[test]
+    fun lsh_valid_usage_test() {
+        assert!(lsh(0, 0) == 0, 0);
+        assert!(lsh(1, 0) == 1, 0);
+        assert!(lsh(2, 0) == 2, 0);
+        assert!(lsh(3, 0) == 3, 0);
+        assert!(lsh(16, 0) == 16, 0);
+        assert!(lsh(17, 0) == 17, 0);
+
+        assert!(lsh(0, 1) == 0, 0);
+        assert!(lsh(1, 1) == 2, 0);
+        assert!(lsh(2, 1) == 4, 0);
+        assert!(lsh(3, 1) == 6, 0);
+        assert!(lsh(16, 1) == 32, 0);
+        assert!(lsh(17, 1) == 34, 0);
+        assert!(lsh(18, 2) == 72, 0);
+    }
+
+    fun rsh(x: u64, y: u8): u64 {
+        let ret = x;
+        ret >>= y;
+        ret
+    }
+
+    #[test]
+    fun rsh_valid_usage_test() {
+        assert!(rsh(0, 0) == 0, 0);
+        assert!(rsh(1, 0) == 1, 0);
+        assert!(rsh(2, 0) == 2, 0);
+        assert!(rsh(3, 0) == 3, 0);
+        assert!(rsh(16, 0) == 16, 0);
+        assert!(rsh(17, 0) == 17, 0);
+
+        assert!(rsh(0, 1) == 0, 0);
+        assert!(rsh(1, 1) == 0, 0);
+        assert!(rsh(2, 1) == 1, 0);
+        assert!(rsh(3, 1) == 1, 0);
+        assert!(rsh(16, 1) == 8, 0);
+        assert!(rsh(17, 1) == 8, 0);
+        assert!(rsh(18, 2) == 4, 0);
+    }
+
+    spec sum {
+        ensures result == x+y;
+    }
+
+    spec sub {
+        ensures result == x-y;
+    }
+
+    spec mul {
+        ensures result == x*y;
+    }
+
+    spec mod {
+        aborts_if y == 0;
+        ensures result == x%y;
+    }
+
+    spec div {
+        aborts_if y == 0;
+        ensures result == x/y;
+    }
+
+    spec and {
+        ensures result == int2bv(x) & int2bv(y);
+    }
+
+    spec or {
+        ensures result == int2bv(x) | int2bv(y);
+    }
+
+    spec xor {
+        ensures result == int2bv(x) ^ int2bv(y);
+    }
+
+    spec lsh {
+        aborts_if y >= 64;
+        ensures result == x<<y;
+    }
+
+    spec rsh {
+        aborts_if y >= 64;
+        ensures result == x>>y;
+    }
+}

--- a/move-mutator/tests/move-assets/skip_mutation_examples/sources/BasicOps.move
+++ b/move-mutator/tests/move-assets/skip_mutation_examples/sources/BasicOps.move
@@ -3,7 +3,7 @@ module TestAccount::BasicOps {
         let sum_r = x + y;
 
         spec {
-                assert sum_r == x + y;
+            assert sum_r == x + y;
         };
 
         sum_r
@@ -23,7 +23,7 @@ module TestAccount::BasicOps {
         let sub_r = x - y;
 
         spec {
-                assert sub_r == x - y;
+            assert sub_r == x - y;
         };
 
         sub_r

--- a/move-spec-test/tests/integration_tests.rs
+++ b/move-spec-test/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 use log::info;
-use move_package::BuildConfig;
+use move_model::metadata::LanguageVersion;
+use move_package::{BuildConfig, CompilerConfig};
 use move_spec_test::{cli::CLIOptions, run_spec_test};
 use mutator_common::report::Report;
 use std::{
@@ -22,7 +23,15 @@ fn test_run_spec_test(path: &Path, expected_report: String) -> datatest_stable::
         output: Some(report_file.clone()),
         ..Default::default()
     };
-    let build_cfg = BuildConfig::default();
+
+    // By default, let's run the tests with move 2 features enabled.
+    let build_cfg = BuildConfig {
+        compiler_config: CompilerConfig {
+            language_version: Some(LanguageVersion::V2_1),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
 
     stacker::maybe_grow(RED_ZONE, STACK_SIZE, || {
         run_spec_test(&cli_opts, &build_cfg, package_path)


### PR DESCRIPTION
Suppoting new mutations for the following operations:
- "+="
- "-="
- "*="
- "/="
- "%="
- "|="
- "&="
- "^="
- "<<="
- ">>="

Included a new `simple-move-2-features` project and enabled integration tests for both `move-mutation-test` and `move-spec-test` tools.