### PR TITLE
fix: ensure the tool can handle low number of mutants

### DIFF
--- a/move-mutation-test/src/lib.rs
+++ b/move-mutation-test/src/lib.rs
@@ -111,8 +111,8 @@ pub fn run_mutation_test(
                 let mut benchmark = Benchmark::new();
 
                 let mutant_file = elem.mutant_path();
-                let rayon_tid =
-                    rayon::current_thread_index().expect("failed to fetch rayon thread id");
+                // In case the number of mutants is very low, a single thread might be used.
+                let rayon_tid = rayon::current_thread_index().unwrap_or(0);
                 info!(
                     "job_{rayon_tid}: Running tests for mutant {}",
                     mutant_file.display()

--- a/move-mutator/src/lib.rs
+++ b/move-mutator/src/lib.rs
@@ -158,7 +158,8 @@ pub fn run_move_mutator(
             // An informative description for the mutant.
             let mutant = format!("{module}::{function}: {:?}", mutated_info.mutation);
 
-            let rayon_tid = rayon::current_thread_index().expect("fetching rayon thread id failed");
+            // In case the number of mutants is very low, a single thread might be used.
+            let rayon_tid = rayon::current_thread_index().unwrap_or(0);
             info!("job_{rayon_tid}: Checking mutant {mutant}");
 
             if mutator_configuration.project.verify_mutants {

--- a/move-spec-test/src/lib.rs
+++ b/move-spec-test/src/lib.rs
@@ -103,7 +103,8 @@ pub fn run_spec_test(
             let mut benchmark = Benchmark::new();
 
             let mutant_file = elem.mutant_path();
-            let rayon_tid = rayon::current_thread_index().expect("failed to fetch rayon thread id");
+            // In case the number of mutants is very low, a single thread might be used.
+            let rayon_tid = rayon::current_thread_index().unwrap_or(0);
             info!(
                 "job_{rayon_tid}: Running prover for mutant {}",
                 mutant_file.display()


### PR DESCRIPTION
If we have a single mutant, fetching rayon thread won't work, since rayon won't even be used in such a case.
Do not try to fetch the rayon thread when there is a single mutant present.