### PR TITLE
feat: add `display-report summary` command

### DIFF
--- a/move-mutation-test/src/lib.rs
+++ b/move-mutation-test/src/lib.rs
@@ -201,8 +201,6 @@ pub fn run_mutation_test(
         }
     }
 
-    println!("\nTotal mutants tested: {}", test_report.mutants_tested());
-    println!("Total mutants killed: {}\n", test_report.mutants_killed());
     test_report.print_table();
 
     benchmarks.total_tool_duration.stop();

--- a/move-mutation-test/src/main.rs
+++ b/move-mutation-test/src/main.rs
@@ -9,9 +9,7 @@ use move_mutation_test::{
     cli::{CLIOptions, TestBuildConfig},
     run_mutation_test,
 };
-use mutator_common::display_report::{
-    display_coverage_on_screen, display_mutants_on_screen, DisplayReportCmd, DisplayReportOptions,
-};
+use mutator_common::display_report::DisplayReportOptions;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -46,16 +44,6 @@ fn main() -> anyhow::Result<()> {
             cli_options,
             test_build_config,
         } => run_mutation_test(cli_options, test_build_config),
-        Commands::DisplayReport(display_report) => {
-            let path_to_report = &display_report.path_to_report;
-            let modules = &display_report.modules;
-
-            match &display_report.cmds {
-                DisplayReportCmd::Coverage => display_coverage_on_screen(path_to_report, modules),
-                DisplayReportCmd::Mutants { functions, mutants } => {
-                    display_mutants_on_screen(path_to_report, modules, functions, mutants)
-                },
-            }
-        },
+        Commands::DisplayReport(display_report) => display_report.execute(),
     }
 }

--- a/move-spec-test/src/lib.rs
+++ b/move-spec-test/src/lib.rs
@@ -178,8 +178,6 @@ pub fn run_spec_test(
         }
     }
 
-    println!("\nTotal mutants tested: {}", test_report.mutants_tested());
-    println!("Total mutants killed: {}\n", test_report.mutants_killed());
     test_report.print_table();
 
     benchmarks.total_tool_duration.stop();

--- a/move-spec-test/src/main.rs
+++ b/move-spec-test/src/main.rs
@@ -8,9 +8,7 @@ use clap::{Parser, Subcommand};
 use move_mutator::cli::PackagePathCheck;
 use move_package::BuildConfig;
 use move_spec_test::{cli::CLIOptions, run_spec_test};
-use mutator_common::display_report::{
-    display_coverage_on_screen, display_mutants_on_screen, DisplayReportCmd, DisplayReportOptions,
-};
+use mutator_common::display_report::DisplayReportOptions;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -54,16 +52,6 @@ fn main() -> anyhow::Result<()> {
             let package_path = cli_options.resolve(package_path)?;
             run_spec_test(&cli_options, &build_config, &package_path)
         },
-        Commands::DisplayReport(display_report) => {
-            let path_to_report = &display_report.path_to_report;
-            let modules = &display_report.modules;
-
-            match &display_report.cmds {
-                DisplayReportCmd::Coverage => display_coverage_on_screen(path_to_report, modules),
-                DisplayReportCmd::Mutants { functions, mutants } => {
-                    display_mutants_on_screen(path_to_report, modules, functions, mutants)
-                },
-            }
-        },
+        Commands::DisplayReport(display_report) => display_report.execute(),
     }
 }

--- a/mutator-common/src/report.rs
+++ b/mutator-common/src/report.rs
@@ -154,7 +154,7 @@ impl Report {
     /// Prints the report to stdout in a table format.
     pub fn print_table(&self) {
         let mut builder = Builder::new();
-        builder.push_record(["Module", "Mutants tested", "Mutants killed", "Percentage"]);
+        builder.push_record(["Module", "Mutants tested", "Mutants killed", "Coverage"]);
 
         for (path, stats) in &self.files {
             for stat in stats {
@@ -165,7 +165,7 @@ impl Report {
                 };
 
                 builder.push_record([
-                    format!("{}::{}", path.display(), stat.module_func.clone()),
+                    format!("{}::{}", path.display(), stat.module_func),
                     stat.tested.to_string(),
                     stat.killed.to_string(),
                     format!("{percentage:.2}%"),
@@ -175,7 +175,10 @@ impl Report {
 
         let table = builder.build().with(Style::modern_rounded()).to_string();
 
-        println!("{table}\n\n");
+        println!("{table}");
+        println!("Total mutants tested: {}", self.mutants_tested());
+        println!("Total mutants killed: {}", self.mutants_killed());
+        println!(); // Empty line before the end
     }
 
     // Internal function to increment the chosen stat.


### PR DESCRIPTION
Allow users to display the mutation testing summary from the report.