### PR TITLE
chore: remove short CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,12 @@ _To run these tools, example projects shall be used that are provided [here](htt
 
 To start specification testing, run the following command from the repo directory:
 ```bash
-$ move-spec-test run -p move-mutator/tests/move-assets/same_names
+$ move-spec-test run --package-dir move-mutator/tests/move-assets/same_names
 ```
 
 The generated output should be very similar to the following (there may also be
 some additional _Prover_ logs visible):
 ```text
-Total mutants tested: 4
-Total mutants killed: 4
-
 ╭────────────────────────────────────────────────┬────────────────┬────────────────┬────────────╮
 │ Module                                         │ Mutants tested │ Mutants killed │ Percentage │
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
@@ -112,17 +109,19 @@ Total mutants killed: 4
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
 │ sources/Negation.move::Negation_main           │ 1              │ 1              │ 100.00%    │
 ╰────────────────────────────────────────────────┴────────────────┴────────────────┴────────────╯
+Total mutants tested: 4
+Total mutants killed: 4
 ```
 
 
-To generate a report, use the `-o` option:
+To generate a report, use the `--output` option:
 ```bash
-$ move-spec-test run -p move-mutator/tests/move-assets/poor_spec -o report.txt
+$ move-spec-test run --package-dir move-mutator/tests/move-assets/poor_spec --output report.txt
 ```
 
 The sample `report.txt` generated for the above command contains useful info that can be paired with the `display-report` option:
 ```bash
-$ ./target/release/move-spec-test display-report -p report.txt
+$ move-spec-test display-report coverage --path-to-report report.txt
 The legend is shown below in the table format
 ===================================┬==================================
  mutants killed / mutants in total │ Source code file path
@@ -157,13 +156,10 @@ The legend is shown below in the table format
 
 To start mutation test, run the following command from the repo directory:
 ```bash
-$ move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt
+$ move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt
 ```
 A shortened sample output for the above command will look as follows:
 ```text
-Total mutants tested: 229
-Total mutants killed: 203
-
 ╭────────────────────────────────────────────────┬────────────────┬────────────────┬────────────╮
 │ Module                                         │ Mutants tested │ Mutants killed │ Percentage │
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
@@ -179,11 +175,13 @@ Total mutants killed: 203
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
 │ sources/Sum.move::Sum::sum                     │ 4              │ 4              │ 100.00%    │
 ╰────────────────────────────────────────────────┴────────────────┴────────────────┴────────────╯
+Total mutants tested: 229
+Total mutants killed: 203
 ```
 
 The sample `report.txt` generated for the above command contains useful info that can be paired with the `display-report` option:
 ```bash
-$ move-mutation-test display-report -p report.txt --modules Sum
+$ move-mutation-test display-report coverage --path-to-report report.txt --modules Sum
 The legend is shown below in the table format
 ===================================┬==================================
  mutants killed / mutants in total │ Source code file path
@@ -226,7 +224,7 @@ _Move Specification tool_ runs **Move Mutator** internally, however there is a p
 
 To generate mutants for all files within a test project (for the whole Move package), run:
 ```bash
-$ move-mutator -p move-mutator/tests/move-assets/simple/
+$ move-mutator --package-dir move-mutator/tests/move-assets/simple/
 ```
 By default, the output shall be stored in the `mutants_output` directory unless otherwise specified.
 

--- a/move-mutation-test/README.md
+++ b/move-mutation-test/README.md
@@ -41,14 +41,11 @@ cargo nextest run -r -p move-mutation-test
 
 To start the mutation test, run the following command from the repo directory:
 ```bash
-./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt
+./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt
 ```
 The above command will store the report in a file `report.txt`.
 A shortened sample output for the above command will look as follows:
 ```text
-Total mutants tested: 229
-Total mutants killed: 203
-
 ╭────────────────────────────────────────────────┬────────────────┬────────────────┬────────────╮
 │ Module                                         │ Mutants tested │ Mutants killed │ Percentage │
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
@@ -66,11 +63,13 @@ Total mutants killed: 203
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
 │ sources/Sum.move::Sum::sum                     │ 4              │ 4              │ 100.00%    │
 ╰────────────────────────────────────────────────┴────────────────┴────────────────┴────────────╯
+Total mutants tested: 229
+Total mutants killed: 203
 ```
 
 The sample `report.txt` generated for the above command contains useful info that can be paired with the `display-report` option:
 ```bash
-$ move-mutation-test display-report coverage -p report.txt --modules Sum
+$ ./target/release/move-mutation-test display-report coverage --path-to-report report.txt --modules Sum
 The legend is shown below in the table format
 ===================================┬==================================
  mutants killed / mutants in total │ Source code file path
@@ -134,21 +133,21 @@ _In below examples, the `RUST_LOG` flag is used to provide a more informative ou
 
 To use the tool on only the `Operators` module for the project `simple`, run:
 ```bash
-RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt --move-2 --mutate-modules Operators
-./target/release/move-mutation-test display-report coverage -p report.txt --modules Operators
+RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --move-2 --mutate-modules Operators
+./target/release/move-mutation-test display-report coverage --path-to-report report.txt --modules Operators
 ```
 ------------------------------------------------------------------------------------------------------------
 To use the tool only on functions called `sum` for the project `simple`, run:
 ```bash
-RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt --move-2 --mutate-functions sum
-./target/release/move-mutation-test display-report coverage -p report.txt --modules Operators,Sum
+RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --move-2 --mutate-functions sum
+./target/release/move-mutation-test display-report coverage --path-to-report report.txt --modules Operators,Sum
 ```
 In the output for the above command, the tool will mutate both the `Operators::sum` and `Sum::sum` functions.
 
 If the user wants to mutate only the `sum` function in the `Sum` module, the user can use this command:
 ```bash
-RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple -o report.txt --move-2 --mutate-functions sum --mutate-modules Sum
-./target/release/move-mutation-test display-report coverage -p report.txt --modules Sum
+RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --move-2 --mutate-functions sum --mutate-modules Sum
+./target/release/move-mutation-test display-report coverage --path-to-report report.txt --modules Sum
 ```
 
 [nextest]: https://github.com/nextest-rs/nextest

--- a/move-mutation-test/src/cli.rs
+++ b/move-mutation-test/src/cli.rs
@@ -26,7 +26,6 @@ pub struct CLIOptions {
 
     /// Work only over specified functions (these are not qualifed functions).
     #[clap(
-        short = 'f',
         long,
         value_parser,
         default_value = "all",
@@ -39,7 +38,7 @@ pub struct CLIOptions {
     pub mutator_conf: Option<PathBuf>,
 
     /// Save report to a JSON file.
-    #[clap(short, long, value_parser)]
+    #[clap(long, value_parser)]
     pub output: Option<PathBuf>,
 
     /// Use previously generated mutants.
@@ -97,7 +96,7 @@ pub struct TestBuildConfig {
     pub dump_state: bool,
 
     /// A filter string to determine which unit tests to run.
-    #[clap(long, short)]
+    #[clap(long)]
     pub filter: Option<String>,
 
     /// A boolean value to skip warnings.
@@ -112,7 +111,7 @@ pub struct TestBuildConfig {
     ///
     /// Used mainly for disabling mutants with infinite loops.
     /// The default value is large enough for all normal tests in most projects.
-    #[clap(long = "gas-limit", default_value_t = 1_000_000)]
+    #[clap(long, default_value_t = 1_000_000)]
     pub gas_limit: u64,
 }
 

--- a/move-mutator/README.md
+++ b/move-mutator/README.md
@@ -29,7 +29,7 @@ cargo nextest run -r -p move-mutator
 
 To run the tool, use the command:
 ```bash
-./target/release/move-mutator -m move-mutator/tests/move-assets/simple/sources/Sum.move
+./target/release/move-mutator --move-sources move-mutator/tests/move-assets/file_without_package/Sub.move
 ```
 
 By default, the output shall be stored in the `mutants_output` directory unless
@@ -38,38 +38,37 @@ otherwise specified.
 The mutator tool respects `RUST_LOG` variable, and it will print out as much
 information as the variable allows. To see all the logs run:
 ```bash
-RUST_LOG=trace ./target/release/move-mutator -m move-mutator/tests/move-assets/simple/sources/Sum.move
+RUST_LOG=trace ./target/release/move-mutator --move-sources move-mutator/tests/move-assets/file_without_package/Sub.move
 ```
 There is a possibility of enabling logging only for specific modules. Please
 refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/) documentation for more details.
 
-There are also good tests in the Move Prover repository that can be used to
-check the tool. To run them, execute:
+There are also good tests in the `aptos-core` repository that can be used to check the tool. To run them, execute:
 ```
 git clone https://github.com/aptos-labs/aptos-core.git;
-./target/release/move-mutator -m aptos-core/third_party/move/move-prover/tests/sources/functional/arithm.move;
-./target/release/move-mutator -m aptos-core/third_party/move/move-prover/tests/sources/functional/bitwise_operators.move;
-./target/release/move-mutator -m aptos-core/third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move;
-./target/release/move-mutator -m aptos-core/third_party/move/move-prover/tests/sources/functional/shift.move;
+./target/release/move-mutator --move-sources aptos-core/third_party/move/move-prover/tests/sources/functional/arithm.move;
+./target/release/move-mutator --move-sources aptos-core/third_party/move/move-prover/tests/sources/functional/bitwise_operators.move;
+./target/release/move-mutator --move-sources aptos-core/third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move;
+./target/release/move-mutator --move-sources aptos-core/third_party/move/move-prover/tests/sources/functional/shift.move;
 ```
 and observe `mutants_output` directory after each single command.
 Please note that each call overwrites the previous output.
 
 To generate mutants for all files within a test project (for the whole Move package) run:
 ```bash
-./target/release/move-mutator --package-path move-mutator/tests/move-assets/simple/
+./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/
 ```
 
 You can also examine reports made inside the output directory.
 
 It's also possible to generate mutants for a specific module by using the `--mutate-modules` option:
 ```bash
-./target/release/move-mutator --package-path move-mutator/tests/move-assets/simple/ --mutate-modules "Sum"
+./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mutate-modules Sum
 ```
 Or use the tool to generate mutants for specific functions:
 ```bash
 # This command will generate mutants only for functions named: 'or', 'and' and 'sum'
-./target/release/move-mutator --package-path move-mutator/tests/move-assets/simple/ --mutate-functions or,and,sum
+./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mutate-functions or,and,sum
 ```
 
 The mutator tool generates:
@@ -80,7 +79,7 @@ Generating mutants for the whole package can be time-consuming. To speed up the
 process, mutant verification is disabled by default. To enable it, use the
 `--verify-mutants` option:
 ```bash
-./target/release/move-mutator --package-path move-mutator/tests/move-assets/simple/ --verify-mutants
+./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --verify-mutants
 ```
 Mutants verification is performed by compiling them. If the compilation fails,
 the mutant is considered invalid. It's highly recommended to enable this option

--- a/move-mutator/src/cli.rs
+++ b/move-mutator/src/cli.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 #[serde(default, deny_unknown_fields)]
 pub struct CLIOptions {
     /// The paths to the Move sources.
-    #[clap(long, short, value_parser)]
+    #[clap(long, value_parser)]
     pub move_sources: Vec<PathBuf>,
 
     /// Module names to be mutated.
@@ -22,11 +22,11 @@ pub struct CLIOptions {
     pub mutate_modules: ModuleFilter,
 
     /// Function names to be mutated.
-    #[clap(short = 'f', long, value_parser, default_value = "all")]
+    #[clap(long, value_parser, default_value = "all")]
     pub mutate_functions: FunctionFilter,
 
     /// The path where to put the output files.
-    #[clap(long, short, value_parser)]
+    #[clap(long, value_parser)]
     pub out_mutant_dir: Option<PathBuf>,
 
     /// Indicates if mutants should be verified and made sure mutants can compile.
@@ -34,7 +34,7 @@ pub struct CLIOptions {
     pub verify_mutants: bool,
 
     /// Indicates if the output files should be overwritten.
-    #[clap(long, short, default_value = "false")]
+    #[clap(long, default_value = "false")]
     pub no_overwrite: bool,
 
     /// Remove averagely given percentage of mutants. See the doc for more details.
@@ -42,7 +42,7 @@ pub struct CLIOptions {
     pub downsampling_ratio_percentage: Option<usize>,
 
     /// Optional configuration file. If provided, it will override the default configuration.
-    #[clap(long, short, value_parser, conflicts_with = "move_sources")]
+    #[clap(long, value_parser, conflicts_with = "move_sources")]
     pub configuration_file: Option<PathBuf>,
 
     /// Use the unit test coverage report to generate mutants for source code with unit test coverage.

--- a/move-mutator/src/main.rs
+++ b/move-mutator/src/main.rs
@@ -10,15 +10,13 @@ use move_mutator::{
     run_move_mutator,
 };
 use move_package::BuildConfig;
-use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Default, Parser, Debug, Clone, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[derive(Default, Parser, Debug, Clone)]
 pub struct Opts {
     /// The path to the target Move package.
-    #[clap(long, short, value_parser)]
-    pub package_path: Option<PathBuf>,
+    #[clap(long, value_parser)]
+    pub package_dir: Option<PathBuf>,
 
     /// Command line options for mutator.
     #[clap(flatten)]
@@ -32,7 +30,7 @@ pub struct Opts {
 fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
 
-    let package_path = opts.cli_options.resolve(opts.package_path)?;
+    let package_path = opts.cli_options.resolve(opts.package_dir)?;
 
     run_move_mutator(opts.cli_options, &opts.build_config, &package_path)
 }

--- a/move-spec-test/README.md
+++ b/move-spec-test/README.md
@@ -51,15 +51,12 @@ the Move Specification Test tool should work as well.
 
 To check if Move Specification Test tool works, run the following command:
 ```bash
-./target/release/move-spec-test run -p move-mutator/tests/move-assets/same_names
+./target/release/move-spec-test run --package-dir move-mutator/tests/move-assets/same_names
 ```
 
 There should be output generated similar to the following (there may also be
 some additional Prover logs visible):
 ```text
-Total mutants tested: 4
-Total mutants killed: 4
-
 ╭────────────────────────────────────────────────┬────────────────┬────────────────┬────────────╮
 │ Module                                         │ Mutants tested │ Mutants killed │ Percentage │
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
@@ -71,6 +68,8 @@ Total mutants killed: 4
 ├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
 │ sources/Negation.move::Negation_main           │ 1              │ 1              │ 100.00%    │
 ╰────────────────────────────────────────────────┴────────────────┴────────────────┴────────────╯
+Total mutants tested: 4
+Total mutants killed: 4
 ```
 
 The specification testing tool respects `RUST_LOG` variable, and it will print
@@ -78,9 +77,9 @@ out as much information as the variable allows. There is possibility to enable
 logging only for the specific modules. Please refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/)
 documentation for more details.
 
-To generate a report, use the `-o` option:
+To generate a report, use the `--output` option:
 ```bash
-./target/release/move-spec-test run -p move-mutator/tests/move-assets/poor_spec -o report.txt
+./target/release/move-spec-test run --package-dir move-mutator/tests/move-assets/poor_spec --output report.txt
 ```
 
 The sample `report.txt` generated for the above command contains useful info that can be paired with the `display-report` option:
@@ -119,7 +118,7 @@ The legend is shown below in the table format
 You can try to run the tool using other examples from the `move-mutator`
 tests like:
 ```bash
-./target/release/move-spec-test run -p move-mutator/tests/move-assets/simple
+./target/release/move-spec-test run --package-dir move-mutator/tests/move-assets/simple
 ```
 
 You should see different results for different modules as it depends on the

--- a/move-spec-test/src/cli.rs
+++ b/move-spec-test/src/cli.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 #[serde(default, deny_unknown_fields)]
 pub struct CLIOptions {
     /// The paths to the Move sources.
-    #[clap(long, short, value_parser)]
+    #[clap(long, value_parser)]
     pub move_sources: Vec<PathBuf>,
 
     /// Work only over specified modules.
@@ -26,7 +26,6 @@ pub struct CLIOptions {
 
     /// Work only over specified functions (these are not qualifed functions).
     #[clap(
-        short = 'f',
         long,
         value_parser,
         default_value = "all",
@@ -43,11 +42,11 @@ pub struct CLIOptions {
     pub prover_conf: Option<PathBuf>,
 
     /// Save report to a JSON file.
-    #[clap(short, long, value_parser)]
+    #[clap(long, value_parser)]
     pub output: Option<PathBuf>,
 
     /// Use previously generated mutants.
-    #[clap(long, short, value_parser)]
+    #[clap(long, value_parser)]
     pub use_generated_mutants: Option<PathBuf>,
 
     /// Indicates if mutants should be verified and made sure mutants can compile.

--- a/move-spec-test/src/main.rs
+++ b/move-spec-test/src/main.rs
@@ -24,8 +24,8 @@ enum Commands {
     /// Runs the specification test tool.
     Run {
         /// The path to the target Move package.
-        #[clap(long, short, value_parser)]
-        package_path: Option<PathBuf>,
+        #[clap(long, value_parser)]
+        package_dir: Option<PathBuf>,
 
         /// Command line options for specification tester.
         #[clap(flatten)]
@@ -45,11 +45,11 @@ fn main() -> anyhow::Result<()> {
 
     match opts.command {
         Commands::Run {
-            package_path,
+            package_dir,
             cli_options,
             build_config,
         } => {
-            let package_path = cli_options.resolve(package_path)?;
+            let package_path = cli_options.resolve(package_dir)?;
             run_spec_test(&cli_options, &build_config, &package_path)
         },
         Commands::DisplayReport(display_report) => display_report.execute(),

--- a/mutator-common/src/report.rs
+++ b/mutator-common/src/report.rs
@@ -154,7 +154,7 @@ impl Report {
     /// Prints the report to stdout in a table format.
     pub fn print_table(&self) {
         let mut builder = Builder::new();
-        builder.push_record(["Module", "Mutants tested", "Mutants killed", "Coverage"]);
+        builder.push_record(["Module", "Mutants tested", "Mutants killed", "Percentage"]);
 
         for (path, stats) in &self.files {
             for stat in stats {


### PR DESCRIPTION
Short CLI args are not used in aptos-core, so our tooling should align. Also: use the `package-dir` (which is more common in `aptos-core`) instead of the `package-path` option.