### PR TITLE
fix: realign operators in the --mode flag and add new ones

### DIFF
--- a/move-mutation-test/README.md
+++ b/move-mutation-test/README.md
@@ -162,17 +162,32 @@ RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator
 ./target/release/move-mutation-test display-report coverage --path-to-report report.txt --modules Sum
 ```
 ------------------------------------------------------------------------------------------------------------
-To speed up mutation testing by using only the [most effective operators](../move-mutator/doc/design.md#operator-effectiveness-analysis), use the `--mode` option:
+To optimize mutation testing by selecting operators based on their ability to [detect test coverage gaps](../move-mutator/doc/design.md#operator-effectiveness-analysis), use the `--mode` option. Operators that produce more surviving mutants are more effective at revealing gaps in test coverage, as surviving mutants indicate untested code paths.
+
 ```bash
-# Light mode - fastest, uses only top 3 most effective operators
+# Light mode - operators optimized for detecting test gaps with fewest mutants
 RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --mode light
 
-# Medium mode - balanced, uses top 5 most effective operators
+# Medium mode - light + additional operators for broader test gap detection
 RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --mode medium
 
-# Heavy mode - default, uses all operators
+# Medium-only mode - only the operator added in medium (not including light)
+RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --mode medium-only
+
+# Heavy mode - default, all operators for maximum test gap detection
 RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --mode heavy
+
+# Heavy-only mode - only the operators added in heavy (not including light/medium)
+RUST_LOG=info ./target/release/move-mutation-test run --package-dir move-mutator/tests/move-assets/simple --output report.txt --mode heavy-only
 ```
+
+The modes include:
+- **light**: `binary_operator_swap`, `break_continue_replacement`, `delete_statement` (3 operators)
+- **medium**: light + `literal_replacement` (4 operators)
+- **medium-only**: `literal_replacement` (1 operator - only what's added in medium)
+- **heavy**: all 7 operators
+- **heavy-only**: `unary_operator_replacement`, `binary_operator_replacement`, `if_else_replacement` (3 operators - only what's added in heavy)
+
 ------------------------------------------------------------------------------------------------------------
 For fine-grained control over which operators to apply, use the `--operators` option with a comma-separated list:
 ```bash

--- a/move-mutation-test/src/cli.rs
+++ b/move-mutation-test/src/cli.rs
@@ -43,11 +43,13 @@ pub struct CLIOptions {
     #[clap(long, conflicts_with = "use_generated_mutants")]
     pub downsampling_ratio_percentage: Option<usize>,
 
-    /// Mutation operator mode: light (fastest), medium (balanced), or heavy (full coverage, default).
+    /// Mutation operator mode to balance speed and test gap detection.
     ///
-    /// - light: unary_operator_replacement, delete_statement, break_continue_replacement
-    /// - medium: light + binary_operator_replacement, if_else_replacement
-    /// - heavy (default): medium + literal_replacement, binary_operator_swap
+    /// - light: binary_operator_swap, break_continue_replacement, delete_statement
+    /// - medium: light + literal_replacement
+    /// - medium-only: literal_replacement (only what's added in medium)
+    /// - heavy (default): all 7 operators
+    /// - heavy-only: unary_operator_replacement, binary_operator_replacement, if_else_replacement (only what's added in heavy)
     #[clap(
         long,
         value_enum,
@@ -58,7 +60,7 @@ pub struct CLIOptions {
 
     /// Custom operator selection to run mutations on (comma-separated).
     ///
-    /// Available operators: unary_operator_replacement, delete_statement, break_continue_replacement, binary_operator_replacement, if_else_replacement,w literal_replacement, binary_operator_swap
+    /// Available operators: unary_operator_replacement, delete_statement, break_continue_replacement, binary_operator_replacement, if_else_replacement, literal_replacement, binary_operator_swap
     #[clap(
         long,
         value_parser,

--- a/move-mutator/README.md
+++ b/move-mutator/README.md
@@ -110,24 +110,32 @@ To check possible options, use the `--help` option.
 
 ### Operator modes
 
-The mutator tool supports different operator modes to control which mutation operators are applied. This can significantly reduce mutation testing time by focusing on the most effective operators.
+The mutator tool supports different operator modes to control which mutation operators are applied. Modes are designed to balance speed and the ability to detect test gaps. Operators that produce more surviving mutants are more effective at revealing gaps in test coverage, as surviving mutants indicate untested code paths.
 
 Use the `--mode` option to select a predefined operator set:
 ```bash
-# Light mode: fastest, uses only the top 3 most effective operators
+# Light mode: operators optimized for detecting test gaps with fewest mutants
 ./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mode light
 
-# Medium mode: balanced, uses the top 5 most effective operators
+# Medium mode: light + additional operators for broader test gap detection
 ./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mode medium
 
-# Heavy mode (default): uses all 7 available operators
+# Medium-only mode: only the operator added in medium (not including light)
+./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mode medium-only
+
+# Heavy mode (default): all available operators for maximum test gap detection
 ./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mode heavy
+
+# Heavy-only mode: only the operators added in heavy (not including light/medium)
+./target/release/move-mutator --package-dir move-mutator/tests/move-assets/simple/ --mode heavy-only
 ```
 
-The operator modes are based on [effectiveness analysis](doc/design.md#operator-effectiveness-analysis) where:
-- **light**: `unary_operator_replacement`, `delete_statement`, `break_continue_replacement`
-- **medium**: light + `binary_operator_replacement`, `if_else_replacement`
-- **heavy**: medium + `literal_replacement`, `binary_operator_swap`
+The operator modes are based on [effectiveness analysis](doc/design.md#operator-effectiveness-analysis) where effectiveness measures the ability to detect test coverage gaps:
+- **light**: `binary_operator_swap`, `break_continue_replacement`, `delete_statement` (3 operators)
+- **medium**: light + `literal_replacement` (4 operators)
+- **medium-only**: `literal_replacement` (1 operator - only what's added in medium)
+- **heavy**: all 7 operators
+- **heavy-only**: `unary_operator_replacement`, `binary_operator_replacement`, `if_else_replacement` (3 operators - only what's added in heavy)
 
 For fine-grained control, use the `--operators` option to specify exactly which operators to apply:
 ```bash

--- a/move-mutator/doc/design.md
+++ b/move-mutator/doc/design.md
@@ -212,10 +212,16 @@ operators are applied during the mutation process. This feature allows users to
 focus on specific operators or use predefined modes based on [operator
 effectiveness](#operator-effectiveness-analysis).
 
-Three predefined modes are available:
-- **Light mode**: Uses the top 3 most effective operators (approximately 95% faster than heavy mode)
-- **Medium mode**: Uses the top 5 most effective operators (approximately 40% faster than heavy mode)
-- **Heavy mode** (default): Uses all 7 available operators
+Modes are designed to balance speed and the ability to detect test gaps. Operators
+that produce more surviving mutants are more effective at revealing gaps in test
+coverage, as surviving mutants indicate untested code paths.
+
+Five predefined modes are available:
+- **Light mode**: `binary_operator_swap`, `break_continue_replacement`, `delete_statement` (3 operators)
+- **Medium mode**: Light + `literal_replacement` (4 operators)
+- **Medium-only mode**: `literal_replacement` (1 operator - only what's added in medium)
+- **Heavy mode** (default): All 7 available operators
+- **Heavy-only mode**: `unary_operator_replacement`, `binary_operator_replacement`, `if_else_replacement` (3 operators - only what's added in heavy)
 
 Users can also specify custom operator sets using the `--operators` CLI option,
 providing a comma-separated list of operator names. This allows for fine-grained
@@ -228,35 +234,40 @@ prevents unnecessary mutant generation, making the process more efficient.
 
 #### Operator effectiveness analysis
 
-The effectiveness rankings were calculated by running the tool on the largest
-projects in [Aptos' Move Framework](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/framework), testing 22,597 mutants with an overall kill
-rate of 82.02%. Operators are ranked by their effectiveness (percentage of
-mutants killed by tests):
+The data below was calculated by running the tool on the largest projects in
+[Aptos' Move Framework](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/framework),
+testing 22,597 mutants with an overall kill rate of 82.02%.
+
+The "Kill Rate" column shows the percentage of mutants killed by tests. While a
+high kill rate indicates good test coverage, operators with **lower kill rates**
+(more surviving mutants) are often **more effective at detecting test gaps**, as
+surviving mutants reveal untested code paths. This is valuable for identifying
+weaknesses in test suites.
 
 ```
 ╭──────┬─────────────────────────────┬────────┬────────┬───────────────┬───────────╮
-│ Rank │ Operator                    │ Tested │ Killed │ Effectiveness │ Kill Rate │
+│ Rank │ Operator                    │ Tested │ Killed │ Kill Rate     │ Survived  │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #1   │ unary_operator_replacement  │ 219    │ 219    │ 100.00%       │ 219/219   │
+│ #1   │ unary_operator_replacement  │ 219    │ 219    │ 100.00%       │ 0/219     │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #2   │ delete_statement            │ 909    │ 895    │ 98.46%        │ 895/909   │
+│ #2   │ delete_statement            │ 909    │ 895    │ 98.46%        │ 14/909    │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #3   │ break_continue_replacement  │ 26     │ 23     │ 88.46%        │ 23/26     │
+│ #3   │ break_continue_replacement  │ 26     │ 23     │ 88.46%        │ 3/26      │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #4   │ binary_operator_replacement │ 7081   │ 6207   │ 87.66%        │ 6207/7081 │
+│ #4   │ binary_operator_replacement │ 7081   │ 6207   │ 87.66%        │ 874/7081  │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #5   │ if_else_replacement         │ 5310   │ 4579   │ 86.23%        │ 4579/5310 │
+│ #5   │ if_else_replacement         │ 5310   │ 4579   │ 86.23%        │ 731/5310  │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #6   │ literal_replacement         │ 8781   │ 6498   │ 74.00%        │ 6498/8781 │
+│ #6   │ literal_replacement         │ 8781   │ 6498   │ 74.00%        │ 2283/8781 │
 ├──────┼─────────────────────────────┼────────┼────────┼───────────────┼───────────┤
-│ #7   │ binary_operator_swap        │ 271    │ 114    │ 42.07%        │ 114/271   │
+│ #7   │ binary_operator_swap        │ 271    │ 114    │ 42.07%        │ 157/271   │
 ╰──────┴─────────────────────────────┴────────┴────────┴───────────────┴───────────╯
 ```
 
-The predefined operator modes are based on this analysis:
-- **Light mode** includes operators #1-3 (effectiveness ≥88%)
-- **Medium mode** includes operators #1-5 (effectiveness ≥86%)
-- **Heavy mode** includes all operators #1-7
+The predefined operator modes balance speed with test gap detection capability:
+- **Light mode**: Operators with lower kill rates that efficiently reveal test gaps (3 operators)
+- **Medium mode**: Light + operators that generate more comprehensive test coverage analysis (4 operators)
+- **Heavy mode**: All operators for maximum test gap detection (7 operators)
 
 The Move mutator tool implements the following mutation operators.
 

--- a/move-mutator/src/cli.rs
+++ b/move-mutator/src/cli.rs
@@ -12,7 +12,9 @@ pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 pub enum OperatorModeArg {
     Light,
     Medium,
+    MediumOnly,
     Heavy,
+    HeavyOnly,
 }
 
 /// Command line options for mutator
@@ -50,17 +52,19 @@ pub struct CLIOptions {
     #[clap(long = "coverage", conflicts_with = "move_sources")]
     pub apply_coverage: bool,
 
-    /// Mutation operator mode: light (fastest), medium (balanced), or heavy (full coverage, default).
+    /// Mutation operator mode to balance speed and test gap detection.
     ///
-    /// - light: unary_operator_replacement, delete_statement, break_continue_replacement
-    /// - medium: light + binary_operator_replacement, if_else_replacement
-    /// - heavy (default): medium + literal_replacement, binary_operator_swap
+    /// - light: binary_operator_swap, break_continue_replacement, delete_statement
+    /// - medium: light + literal_replacement
+    /// - medium-only: literal_replacement (only what's added in medium)
+    /// - heavy (default): all 7 operators
+    /// - heavy-only: unary_operator_replacement, binary_operator_replacement, if_else_replacement (only what's added in heavy)
     #[clap(long, value_enum, conflicts_with = "operators")]
     pub mode: Option<OperatorModeArg>,
 
     /// Custom operator selection to run mutations on (comma-separated).
     ///
-    /// Available operators: unary_operator_replacement, delete_statement, break_continue_replacement, binary_operator_replacement, if_else_replacement,w literal_replacement, binary_operator_swap
+    /// Available operators: unary_operator_replacement, delete_statement, break_continue_replacement, binary_operator_replacement, if_else_replacement, literal_replacement, binary_operator_swap
     #[clap(long, value_parser, value_delimiter = ',', conflicts_with = "mode")]
     pub operators: Option<Vec<String>>,
 }

--- a/move-mutator/src/configuration.rs
+++ b/move-mutator/src/configuration.rs
@@ -49,7 +49,9 @@ impl Configuration {
                 let mode = match mode_arg {
                     OperatorModeArg::Light => OperatorMode::Light,
                     OperatorModeArg::Medium => OperatorMode::Medium,
+                    OperatorModeArg::MediumOnly => OperatorMode::MediumOnly,
                     OperatorModeArg::Heavy => OperatorMode::Heavy,
+                    OperatorModeArg::HeavyOnly => OperatorMode::HeavyOnly,
                 };
                 Ok(mode)
             },


### PR DESCRIPTION
  - Updated mode assignments:
    - **Light**: `binary_operator_swap`, `break_continue_replacement`, `delete_statement` (3 operators)
    - **Medium**: Light + `literal_replacement` (4 operators)
    - **Heavy**: All 7 operators (default, unchanged)

- New modes added:
  - `--mode medium-only`: Only `literal_replacement` (what's added in medium, excluding light operators)
  - `--mode heavy-only`: Only `unary_operator_replacement`, `binary_operator_replacement`, `if_else_replacement` (what's added in heavy, excluding light/medium operators)